### PR TITLE
Adds support for what4 1.1

### DIFF
--- a/lib/copilot-theorem/copilot-theorem.cabal
+++ b/lib/copilot-theorem/copilot-theorem.cabal
@@ -60,6 +60,7 @@ library
                           , data-default  >= 0.7 && < 0.8
                           , directory     >= 1.3 && < 1.4
                           , filepath      >= 1.4.2 && < 1.5
+                          , libBF         >= 0.6.2 && < 0.7
                           , mtl           >= 2.0 && < 2.3
                           , panic         >= 0.4.0 && < 0.5
                           , parsec        >= 2.0 && < 3.2
@@ -69,7 +70,7 @@ library
                           , random        >= 1.1 && < 1.2
                           , transformers  >= 0.5 && < 0.6
                           , xml           >= 1.3 && < 1.4
-                          , what4         >= 1.0 && < 1.2
+                          , what4         >= 1.1 && < 1.2
 
                           , copilot-core  >= 3.2.1 && < 3.3
 


### PR DESCRIPTION
This commit makes the changes required to the what4 translation for what4-1.1
compatibility.

There were two significant changes that affected Copilot.Theorem.What4. The
first was the type of ExprSymFn changed trivially; it no longer requires (Expr
t) as an argument. The second was that concrete floating point operations are
now implemented, and the libBF library is used for that, so several types
changed from raw bitvectors to libBF floats.