### PR TITLE
Remove ghc-prim dependency from copilot-language. (#220)

### DIFF
--- a/lib/copilot-language/CHANGELOG
+++ b/lib/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2021-07-07
+        * Remove ghc-prim dependency from copilot-language. (#220)
+
 2021-05-07
         * Version bump (3.3). (#217)
         * Remove unused type. (#110)

--- a/lib/copilot-language/copilot-language.cabal
+++ b/lib/copilot-language/copilot-language.cabal
@@ -38,7 +38,6 @@ library
                , containers      >= 0.4 && < 0.7
                , data-reify      >= 0.6 && < 0.7
                , mtl             >= 2.0 && < 3
-               , ghc-prim        >= 0.3 && < 0.7
 
                , copilot-core    >= 3.3 && < 3.4
                , copilot-theorem >= 3.3 && < 3.4


### PR DESCRIPTION
Remove `ghc-prim` from the dependencies of `copilot-language`. 

Issue: https://github.com/Copilot-Language/copilot/issues/220

## Testing process:

### `Dockerfile` (borrowed from the travis file)

```
FROM haskell:8.10.4

RUN apt-get update
RUN apt-get install -y software-properties-common
RUN add-apt-repository -y ppa:hvr/ghc
RUN apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
RUN export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
RUN cabal --version
RUN echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
RUN cabal update
```

### `docker-compose.yml`

```
version: '3.9'
services:
    haskell:
        image: copilot:local
        build: 
            context: .
        volumes: 
            - .:/root
        working_dir: /root
```

### Build

```
docker-compose run --rm haskell bash -c "cabal v2-build"
```

### Result

The build was successful.