### PR TITLE
Marked showWit as deprecated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2021-07-07
+        * Deprecated `showWit`. (#220)
+
 2021-05-07
         * Version bump (3.3). (#217)
         * Document installation process without git submodules. (#214)

--- a/lib/copilot-core/src/Copilot/Core/Type/Show.hs
+++ b/lib/copilot-core/src/Copilot/Core/Type/Show.hs
@@ -24,6 +24,7 @@ data ShowWit a = Show a => ShowWit
 --------------------------------------------------------------------------------
 
 -- | Turn a type into a show witness.
+{-# DEPRECATED showWit "This function is deprecated in Copilot 3.4." #-}
 showWit :: Type a -> ShowWit a
 showWit t =
   case t of


### PR DESCRIPTION
The function is still exported, but marked as deprecated. In later releases, the function and export should be removed.