### PR TITLE
Marked `Copilot.Core.Type.Read` as deprecated

### DIFF
--- a/lib/copilot-core/CHANGELOG
+++ b/lib/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2021-07-07
+        * Deprecated `Copilot.Core.Type.Read` module. (#144)
+
 2021-05-07
         * Version bump (3.3). (#217)
         * Fix URL in bug-reports field in cabal file. (#215)

--- a/lib/copilot-core/src/Copilot/Core/Type/Read.hs
+++ b/lib/copilot-core/src/Copilot/Core/Type/Read.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ExistentialQuantification, GADTs #-}
 
 module Copilot.Core.Type.Read
+  {-# DEPRECATED "This module is deprecated." #-}
   ( ReadWit (..)
   , readWit
   , readWithType


### PR DESCRIPTION
The module is unused and marked deprecated.