### PR TITLE
Remove U2 type (#91)

### DIFF
--- a/lib/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
+++ b/lib/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
@@ -7,7 +7,6 @@
 module Copilot.Theorem.TransSys.Type
   ( Type (..)
   , U (..)
-  , U2 (..)
   ) where
 
 import Copilot.Core.Type.Equality
@@ -35,7 +34,6 @@ instance EqualType Type where
 --
 -- For instance, 'U Expr' is the type of an expression of unknown type
 data U f = forall t . U (f t)
-data U2 f g = forall t . U2 (f t) (g t)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Issue #91 has been around for a while. 

I've removed the `U2` type and `cabal v2-build` was successful.
