### PR TITLE
Fix code generation for stream buffer access

### DIFF
--- a/lib/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/lib/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -53,6 +53,16 @@ mkindexdecln sid = C.VarDecln (Just C.Static) cty name initval where
   cty     = C.TypeSpec $ C.TypedefName "size_t"
   initval = Just $ C.InitExpr $ C.LitInt 0
 
+-- | Define an accessor functions for the ring buffer associated with a stream
+mkaccessdecln :: Id -> Type a -> [a] -> C.FunDef
+mkaccessdecln sid ty xs = C.FunDef cty name params [] [C.Return (Just expr)] where
+  cty        = C.decay $ transtype ty
+  name       = streamaccessorname sid
+  bufflength = C.LitInt $ fromIntegral $ length xs
+  params     = [C.Param (C.TypeSpec $ C.TypedefName "size_t") "x"]
+  index      = (C.Ident (indexname sid) C..+ C.Ident "x") C..% bufflength
+  expr       = C.Index (C.Ident (streamname sid)) index
+
 -- | Writes the step function, that updates all streams.
 mkstep :: [Stream] -> [Trigger] -> [External] -> C.FunDef
 mkstep streams triggers exts = C.FunDef void "step" [] declns stmts where

--- a/lib/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/lib/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -77,10 +77,16 @@ compilec spec = C.TransUnit declns funs where
     buffdecln  (Stream sid buff _ ty) = mkbuffdecln  sid ty buff
     indexdecln (Stream sid _    _ _ ) = mkindexdecln sid
 
+
   -- Make generator functions, including trigger arguments.
   genfuns :: [Stream] -> [Trigger] -> [C.FunDef]
-  genfuns streams triggers =  map streamgen streams
+  genfuns streams triggers =  map accessdecln streams
+                           ++ map streamgen streams
                            ++ concatMap triggergen triggers where
+
+    accessdecln :: Stream -> C.FunDef
+    accessdecln (Stream sid buff _ ty) = mkaccessdecln sid ty buff
+
     streamgen :: Stream -> C.FunDef
     streamgen (Stream sid _ expr ty) = genfun (generatorname sid) expr ty
 

--- a/lib/copilot-c99/src/Copilot/Compile/C99/Translate.hs
+++ b/lib/copilot-c99/src/Copilot/Compile/C99/Translate.hs
@@ -25,12 +25,9 @@ transexpr (Local ty1 _ name e1 e2) = do
 transexpr (Var _ n) = return $ C.Ident n
 
 transexpr (Drop _ amount sid) = do
-  let var    = streamname sid
-      indexvar = indexname sid
-      index  = case amount of
-        0 -> C.Ident indexvar
-        n -> C.Ident indexvar C..+ C.LitInt (fromIntegral n)
-  return $ C.Index (C.Ident var) index
+  let accessvar = streamaccessorname sid
+      index     = C.LitInt (fromIntegral amount)
+  return $ funcall accessvar [index]
 
 transexpr (ExternVar _ name _) = return $ C.Ident (excpyname name)
 

--- a/lib/copilot-c99/src/Copilot/Compile/C99/Util.hs
+++ b/lib/copilot-c99/src/Copilot/Compile/C99/Util.hs
@@ -33,6 +33,10 @@ streamname sid = "s" ++ show sid
 indexname :: Id -> String
 indexname sid = streamname sid ++ "_idx"
 
+-- | Turn a stream id into the name of its accessor function
+streamaccessorname :: Id -> String
+streamaccessorname sid = streamname sid ++ "_get"
+
 -- | Add a postfix for copies of external variables the name.
 excpyname :: String -> String
 excpyname name = name ++ "_cpy"


### PR DESCRIPTION
Previously, indexing into ring buffers for delayed stream values
was being calculated incorrectly. The base pointer for the ring
buffer was being correctly reduced modulo the array length,
but buffer access indexing was not.

This PR causes code generation to introduce a new sequence of
`sXXX_get()` accessor functions that uniformly compute the correct
ring-buffer access from the base index and use those in place
of the previous, incorrect, indexing computation.

Fixes #238