### PR TITLE
`copilot-c99`: Make `typetypes` respect dependency order. Refs #275.

### DIFF
--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -165,8 +165,8 @@ exprtypes e = case e of
 -- | List all types of a type, returns items uniquely.
 typetypes :: Typeable a => Type a -> [UType]
 typetypes ty = case ty of
-  Array ty' -> [UType ty] `union` typetypes ty'
-  Struct x  -> [UType ty] `union` map (\(Value ty' _) -> UType ty') (toValues x)
+  Array ty' -> typetypes ty' `union` [UType ty]
+  Struct x  -> concatMap (\(Value ty' _) -> typetypes ty') (toValues x) `union` [UType ty]
   _         -> [UType ty]
 
 -- | Collect all expression of a list of streams and triggers and wrap them

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -192,6 +192,18 @@ executable heater
     else
       buildable: False
 
+executable structs
+    main-is:            Structs.hs
+    hs-source-dirs:     examples
+    build-depends:      base              >= 4.9  && < 5
+                      , copilot
+                      , copilot-c99
+    default-language:   Haskell2010
+    if flag(examples)
+      buildable: True
+    else
+      buildable: False
+
 executable voting
     main-is:            Voting.hs
     hs-source-dirs:     examples

--- a/copilot/examples/Structs.hs
+++ b/copilot/examples/Structs.hs
@@ -1,0 +1,75 @@
+-- | An example showing how specifications involving structs (in particular,
+-- nested structs) are compiled to C using copilot-c99.
+
+{-# LANGUAGE DataKinds #-}
+
+module Main where
+
+import qualified Prelude as P
+import Control.Monad (void, forM_)
+
+import Language.Copilot
+import Copilot.Compile.C99
+
+
+-- | Definition for `Volts`.
+data Volts = Volts
+  { numVolts :: Field "numVolts" Word16
+  , flag     :: Field "flag"     Bool
+  }
+
+-- | `Struct` instance for `Volts`.
+instance Struct Volts where
+  typename _ = "volts"
+  toValues volts = [ Value Word16 (numVolts volts)
+                   , Value Bool   (flag volts)
+                   ]
+
+-- | `Volts` instance for `Typed`.
+instance Typed Volts where
+  typeOf = Struct (Volts (Field 0) (Field False))
+
+data Battery = Battery
+  { temp  :: Field "temp"  Word16
+  , volts :: Field "volts" (Array 10 Volts)
+  , other :: Field "other" (Array 10 (Array 5 Word32))
+  }
+
+-- | `Battery` instance for `Struct`.
+instance Struct Battery where
+  typename _ = "battery"
+  toValues battery = [ Value typeOf (temp battery)
+                     , Value typeOf (volts battery)
+                     , Value typeOf (other battery)
+                     ]
+
+-- | `Battery` instance for `Typed`. Note that `undefined` is used as an
+-- argument to `Field`. This argument is never used, so `undefined` will never
+-- throw an error.
+instance Typed Battery where
+  typeOf = Struct (Battery (Field 0) (Field undefined) (Field undefined))
+
+spec :: Spec
+spec = do
+  let battery :: Stream Battery
+      battery = extern "battery" Nothing
+
+  -- Check equality, indexing into nested structs and arrays. Note that this is
+  -- trivial by equality.
+  trigger "equalitySameIndex"
+    ((((battery#volts) .!! 0)#numVolts) == (((battery#volts) .!! 0)#numVolts))
+    [arg battery]
+
+  -- Same as previous example, but get a different array index (so should be
+  -- false).
+  trigger "equalityDifferentIndices"
+    ((((battery#other) .!! 2) .!! 3) == (((battery#other) .!! 2) .!! 4))
+    [arg battery]
+
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+
+  -- Compile the specific to C.
+  compile "structs" spec'


### PR DESCRIPTION
`copilot-c99:Copilot.Compile.C99.CodeGen.typetypes` is used during C code generation to compute all of the types mentioned in a type. In particular, the `compilec` function generates struct declarations by computing all of the types mentioned in the program and generating a declaration for each struct type it finds.

Issue #275 revealed two issues with the way `typetypes` was handling its `Struct` case:

1. It was not recursively computing the types mentioned in the fields of a struct. This means that if a struct type had a field whose type transitively used a struct type, the latter struct type would not have a struct declaration generated at all. As a consequence, the generated C code would fail to compile.
2. Moreover, even in cases where `typetypes` _did_ compute all of the struct types mentioned in a program, it would sometimes generate the corresponding struct declarations in the wrong order. This is because `typetypes` would return the overall type of a struct _before_ any of the types mentioned in its fields. As a result, some generated C programs would have a struct field whose type mentions a struct that had not been declared yet (since that declaration would appear later in the file), also causing the program to fail to compile.

This patch fixes both issues:

1. `typetypes` now recursively invokes itself on the result of calling `toValues` on a `Struct` type.
2. `typetypes` now returns the overall type of a `Struct` _after_ the types that are transitively mentioned in the fields of the struct.

   I also applied the fix for (2) to the `Array` case as well for uniformity.