### PR TITLE
`copilot-c99`: Translate `signum` correctly. Refs #278.

### DIFF
--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -204,6 +204,18 @@ executable structs
     else
       buildable: False
 
+executable signum
+    main-is:            Signum.hs
+    hs-source-dirs:     examples
+    build-depends:      base              >= 4.9  && < 5
+                      , copilot
+                      , copilot-c99
+    default-language:   Haskell2010
+    if flag(examples)
+      buildable: True
+    else
+      buildable: False
+
 executable voting
     main-is:            Voting.hs
     hs-source-dirs:     examples

--- a/copilot/examples/Signum.hs
+++ b/copilot/examples/Signum.hs
@@ -1,0 +1,30 @@
+--------------------------------------------------------------------------------
+-- Copyright © 2021 National Institute of Aerospace / Galois, Inc.
+--------------------------------------------------------------------------------
+
+-- | An example of a specification using the 'signum' function.
+
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Main where
+
+import qualified Data.List as List
+
+import Copilot.Compile.C99
+import Language.Copilot
+
+nums :: [Int32]
+nums = [-2, -1, 0, 1, 2]
+
+spec :: Spec
+spec = do
+  let stream :: Stream Int32
+      stream = extern "stream" (Just nums)
+
+  trigger "func" true [arg (signum stream)]
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+  compile "signum" spec'
+  interpret (List.genericLength nums) spec


### PR DESCRIPTION
Previously, `copilot-c99` would translate `signum e` as `copysign(1.0, e)`. However, `signum 0` should return `0`, but `copysign(1.0, 0)` returns `1`. Moreover, when dealing with floating-point numbers, `signum (-0)` and `signum NaN` should return `-0` and `NaN`, respectively, but the `copysign`-based implementation would return `-1.0` and `±1.0` (depending on the sign bit of the `NaN`), respectively. In short: the semantics of `signum` and `copysign` don't coincide.

This replaces the `copysign`-based implementation such that `signum e` now returns `e > 0 ? 1 : (e < 0 ? -1 : e)`. That is, if `e > 0`, return `1`, else if `e < 0`, return `-1`, else return `e`. This correctly handles the cases when `e` is `±0` or `NaN`, since they will all fall back to the "return `e`" case.