### PR TITLE
`copilot-c99`: Use `InitArray` for nested arrays in `constarray`. Refs #276.

### DIFF
--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -45,7 +45,7 @@ mkbuffdecln sid ty xs = C.VarDecln (Just C.Static) cty name initvals where
   name     = streamname sid
   cty      = C.Array (transtype ty) (Just $ C.LitInt $ fromIntegral buffsize)
   buffsize = length xs
-  initvals = Just $ C.InitArray $ map (C.InitExpr . constty ty) xs
+  initvals = Just $ C.InitArray $ constarray ty xs
 
 -- | Make a C index variable and initialise it to 0.
 mkindexdecln :: Id -> C.Decln

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -128,6 +128,7 @@ executable array
     hs-source-dirs:     examples
     build-depends:      base        >= 4.9  && < 5
                       , copilot
+                      , copilot-c99
     default-language:   Haskell2010
     if flag(examples)
       buildable: True

--- a/copilot/examples/Array.hs
+++ b/copilot/examples/Array.hs
@@ -14,6 +14,7 @@
 module Main where
 
 import Language.Copilot
+import Copilot.Compile.C99
 
 -- Lets define an array of length 2.
 -- Make the buffer of the streams 3 elements long.
@@ -32,4 +33,7 @@ spec = do
 
 -- Compile the spec
 main :: IO ()
-main = interpret 30 spec
+main = do
+  interpret 30 spec
+  spec' <- reify spec
+  compile "array" spec'


### PR DESCRIPTION
Previously, `constarray` was using `InitExpr` to represent nested arrays when constructing an initializer for a constant array. This is not what we want, however, as `language-c99`'s pretty-printer will print `InitExpr`s of array types with additional casts that cause C compilers to perform unwanted type conversions. For the full story, see the comments in `constarray`.

The fix is thankfully quite simply: use `InitArray` to represent each nested array. `language-c99`'s pretty-printed does _not_ print these with additional casts, and the resulting code does not give C compilers trouble.