### PR TITLE
Add support for GHC 9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - CABALVER=2.4 GHCVER=8.6.5
   - CABALVER=3.2 GHCVER=8.8.4
   - CABALVER=3.2 GHCVER=8.10.4
+  - CABALVER=3.4 GHCVER=9.0.1
 # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 # Note: the distinction between `before_install` and `install` is not important.

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -72,7 +72,7 @@ library
                           , random        >= 1.1 && < 1.2
                           , transformers  >= 0.5 && < 0.6
                           , xml           >= 1.3 && < 1.4
-                          , what4         >= 1.1 && < 1.3
+                          , what4         >= 1.2 && < 1.3
 
                           , copilot-core  >= 3.7 && < 3.8
 

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2022-02-09
+        * Added support for GHC 9.0. (#284)
+
 2022-01-07
         * Version bump (3.7). (#287)
         * Add example with nested structs. (#275)


### PR DESCRIPTION
This PR adds support for GHC 9.0 and resolves #294.

* Bumped what4 dependency to be at least 1.2.
* Added 9.0.1 to .travis.yml.