### PR TITLE
`copilot-core`: Remove unused type Copilot.Core.Expr.Tag. Refs #304.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2022-04-07
+        * Remove Copilot.Core.Expr.Tag. (#304)
+
 2022-03-07
         * Version bump (3.8). (#298)
         * Replaces uses of the internal Dynamic with base:Data.Dynamic. (#266)

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -12,7 +12,6 @@ module Copilot.Core.Expr
   , Expr (..)
   , UExpr (..)
   , DropIdx
-  , Tag
   ) where
 
 import Copilot.Core.Operators (Op1, Op2, Op3)
@@ -35,12 +34,6 @@ type Name = String
 
 -- | An index for the drop operator.
 type DropIdx = Word32
-
---------------------------------------------------------------------------------
-
--- | A unique tag for external arrays/function calls.
-{-# DEPRECATED Tag "The type Tag is deprecated in Copilot 3.6." #-}
-type Tag = Int
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR removes the type `Copilot.Core.Expr.Tag` completely, as prescribed in the solution proposed for #304.