### PR TITLE
`copilot-c99`: Re-implement translation of signum to C99 to match interpreter. Refs #278.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2022-04-14
+        * Fix issue in C99 implementation of signum. (#278)
+
 2022-03-07
         * Version bump (3.8). (#298)
         * Hide internal modules deprecated in Copilot 3.5. (#289)


### PR DESCRIPTION
This PR reimplements the translation of `Sign` in Copilot Core to match the meaning of `signum` by the Copilot interpreter, as prescribed in the solution proposed for https://github.com/Copilot-Language/copilot/issues/278. See: https://github.com/Copilot-Language/copilot/issues/278#issuecomment-1096749786.