### PR TITLE
`copilot-c99`: Use `InitArray` for nested arrays and structs. Refs #276.

### DIFF
--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -45,7 +45,7 @@ mkbuffdecln sid ty xs = C.VarDecln (Just C.Static) cty name initvals where
   name     = streamname sid
   cty      = C.Array (transtype ty) (Just $ C.LitInt $ fromIntegral buffsize)
   buffsize = length xs
-  initvals = Just $ C.InitArray $ map (C.InitExpr . constty ty) xs
+  initvals = Just $ C.InitArray $ constarray ty xs
 
 -- | Make a C index variable and initialise it to 0.
 mkindexdecln :: Id -> C.Decln


### PR DESCRIPTION
Previously, C99 translation would produce initializers for array and struct values using `InitExpr`. When arrays or structs are nested inside of other arrays or structs, this causes the generated code to be produce warnings when compiled with `gcc -Wpedantic` due to the placement of the casts in the initializer expressions. In the worst case, these arrays could even cause C compilers to perform unwanted type conversions. For the full story, see the comments in the `constinit` function.

To fix the issue, we now include special cases for `Array` and `Struct` such that they are translated using `InitArray`. For example, this means that a nested array will be translated as `{{0, 1}, {2, 3}, {4, 5}}` instead of `{ (int32_t[2]){0, 1}, (int32_t[2]){2, 3}, (int32_t[2]){4, 5} }`. The same syntax also works for structs—for example, an array of structs will be translated as `{ {0, 1, 2} }` instead of `{ (struct foo){0, 1, 2} }`. The use of `InitArray` is a bit odd (one might imagine `{ { .a = 0, .b = 1, .c = 2 } }` instead), but that is an artifact of how `language-c99-simple`'s API works.

Bottom line: fewer casts involving array or struct types, which gives C compilers fewer headaches.