### PR TITLE
`copilot-c99`: Initialize arrays, structs without explicit casts. Refs #276.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,4 +1,5 @@
-2022-04-14
+2022-04-20
+        * Fix issue with delays of streams of structs or arrays. (#276)
         * Fix issue in C99 implementation of signum. (#278)
 
 2022-03-07

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -45,7 +45,7 @@ mkbuffdecln sid ty xs = C.VarDecln (Just C.Static) cty name initvals where
   name     = streamname sid
   cty      = C.Array (transtype ty) (Just $ C.LitInt $ fromIntegral buffsize)
   buffsize = length xs
-  initvals = Just $ C.InitArray $ map (C.InitExpr . constty ty) xs
+  initvals = Just $ C.InitArray $ constarray ty xs
 
 -- | Make a C index variable and initialise it to 0.
 mkindexdecln :: Id -> C.Decln


### PR DESCRIPTION
This PR modifies the implementation of the initializers for arrays and structs so that they are not explicitly cast, as prescribed in the solution proposed for https://github.com/Copilot-Language/copilot/issues/276.

Implementation done by @RyanGlScott ; I have adjusted style, comments, commit messages, and added an entry in the CHANGELOG.