### PR TITLE
`copilot-core`: Remove unused functions Copilot.Core.Type.Dynamic.toDynF,fromDynF. Refs #301.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,4 +1,5 @@
-2022-04-18
+2022-04-22
+        * Remove Copilot.Core.Type.Dynamic.fromDynF,toDynF. (#301)
         * Hide module Copilot.Core.Error. (#300)
         * Remove Copilot.Core.Type.Uninitialized. (#302)
         * Remove Copilot.Core.Expr.Tag. (#304)

--- a/copilot-core/src/Copilot/Core/Type/Dynamic.hs
+++ b/copilot-core/src/Copilot/Core/Type/Dynamic.hs
@@ -21,8 +21,6 @@ module Copilot.Core.Type.Dynamic
   , DynamicF (..)
   , toDyn
   , fromDyn
-  , toDynF
-  , fromDynF
   ) where
 
 import Copilot.Core.Type.Equality
@@ -47,18 +45,4 @@ fromDyn :: EqualType t => t a -> Dynamic t -> Maybe a
 fromDyn t1 (Dynamic x t2) =
   case t1 =~= t2 of
     Just Refl -> return x
-    Nothing   -> Nothing
-
--- | Enclose a function and its type in a container.
-{-# DEPRECATED toDynF "This function is deprecated in Copilot 3.6." #-}
-toDynF :: t a -> f a -> DynamicF f t
-toDynF t fx = DynamicF fx t
-
--- | Extract a value from a dynamic function container. Return 'Nothing' if
--- the value is not of the given type.
-{-# DEPRECATED fromDynF "This function is deprecated in Copilot 3.6." #-}
-fromDynF :: EqualType t => t a -> DynamicF f t -> Maybe (f a)
-fromDynF t1 (DynamicF fx t2) =
-  case t1 =~= t2 of
-    Just Refl -> return fx
     Nothing   -> Nothing


### PR DESCRIPTION
This PR removes the functions Copilot.Core.Type.Dynamic.toDynF and fromDynF completely, as prescribed in the solution proposed for https://github.com/Copilot-Language/copilot/issues/301.