### PR TITLE
`copilot-c99`: Specialize code generated for math operations based on type. Refs #263.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,4 +1,5 @@
-2022-04-20
+2022-04-29
+        * Translate math operations taking type into account. (#263)
         * Fix issue with delays of streams of structs or arrays. (#276)
         * Fix issue in C99 implementation of signum. (#278)
 

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -58,6 +58,7 @@ library
   exposed-modules         : Copilot.Compile.C99
 
   other-modules          : Copilot.Compile.C99.Translate
+                         , Copilot.Compile.C99.Error
                          , Copilot.Compile.C99.Util
                          , Copilot.Compile.C99.CodeGen
                          , Copilot.Compile.C99.External

--- a/copilot-c99/src/Copilot/Compile/C99/Error.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Error.hs
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------------
+-- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
+--------------------------------------------------------------------------------
+{-# LANGUAGE Safe #-}
+
+-- | Custom functions to report error messages to users.
+module Copilot.Compile.C99.Error
+    ( impossible )
+  where
+
+-- | Report an error due to a bug in Copilot.
+impossible :: String -- ^ Name of the function in which the error was detected.
+           -> String -- ^ Name of the package in which the function is located.
+           -> a
+impossible function package =
+  error $ "Impossible error in function "
+    ++ function ++ ", in package " ++ package
+    ++ ". Please file an issue at "
+    ++ "https://github.com/Copilot-Language/copilot/issues"
+    ++ " or email the maintainers at <ivan.perezdominguez@nasa.gov>"

--- a/copilot-c99/src/Copilot/Compile/C99/Translate.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Translate.hs
@@ -55,7 +55,7 @@ transop1 op e = case op of
   Not             -> (C..!) e
   Abs      _      -> funcall "abs"      [e]
   Sign     ty     -> transSign ty e
-  Recip    _      -> C.LitDouble 1.0 C../ e
+  Recip    ty     -> (constNumTy ty 1) C../ e
   Exp      _      -> funcall "exp"   [e]
   Sqrt     _      -> funcall "sqrt"  [e]
   Log      _      -> funcall "log"   [e]
@@ -152,17 +152,6 @@ transSign ty e = positiveCase $ negativeCase e
     negativeCase =
       C.Cond (C.BinaryOp C.LT e (constNumTy ty 0)) (constNumTy ty (-1))
 
-    -- Translate a literal number of type @ty@ into a C99 literal.
-    --
-    -- PRE: The type of PRE is numeric (integer or floating-point), that
-    -- is, not boolean, struct or array.
-    constNumTy :: Type a -> Integer -> C.Expr
-    constNumTy ty =
-      case ty of
-        Float  -> C.LitFloat . fromInteger
-        Double -> C.LitDouble . fromInteger
-        _      -> C.LitInt
-
 -- | Transform a Copilot Core literal, based on its value and type, into a C99
 -- literal.
 constty :: Type a -> a -> C.Expr
@@ -254,3 +243,14 @@ transtype ty = case ty of
 -- | Translate a Copilot type intro a C typename
 transtypename :: Type a -> C.TypeName
 transtypename ty = C.TypeName $ transtype ty
+
+-- Translate a literal number of type @ty@ into a C99 literal.
+--
+-- PRE: The type of PRE is numeric (integer or floating-point), that
+-- is, not boolean, struct or array.
+constNumTy :: Type a -> Integer -> C.Expr
+constNumTy ty =
+  case ty of
+    Float  -> C.LitFloat . fromInteger
+    Double -> C.LitDouble . fromInteger
+    _      -> C.LitInt


### PR DESCRIPTION
This PR modifies the C99 backend so that the code generated for math operations applied to streams depends on the types of the values carried by the streams, as prescribed in the [solution proposed](https://github.com/Copilot-Language/copilot/issues/263#issuecomment-1113871960) for #263.

The PR is divided in three commits: one to deal with recip, one to deal with abs, and one for other functions in `math.h`.