### PR TITLE
Add GHC9 to CI script. Refs #294.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - CABALVER=2.4 GHCVER=8.6.5
   - CABALVER=3.2 GHCVER=8.8.4
   - CABALVER=3.2 GHCVER=8.10.4
+  - CABALVER=3.4 GHCVER=9.0.1
 # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 # Note: the distinction between `before_install` and `install` is not important.

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2022-05-02
+        * Add support for GHC 9.0. (#294)
+
 2022-03-07
         * Version bump (3.8). (#298)
         * Mark package as uncurated to avoid modification. (#288)


### PR DESCRIPTION
Add GHC9 case to CI script so we officially support that version of GHC, as prescribed in the solution to #294.