### PR TITLE
Made changes to use NonEmpty initialisers in C99.

### DIFF
--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -53,7 +53,7 @@ library
                           , copilot-core        >= 3.9   && < 3.10
                           , language-c99        >= 0.1.1 && < 0.2
                           , language-c99-util   >= 0.1.1 && < 0.2
-                          , language-c99-simple >= 0.1.1 && < 0.2
+                          , language-c99-simple >= 0.2   && < 0.3
 
   exposed-modules         : Copilot.Compile.C99
 

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -6,6 +6,7 @@ module Copilot.Compile.C99.CodeGen where
 
 import Control.Monad.State  (runState)
 import Data.List            (union, unzip4)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Typeable        (Typeable)
 
 import qualified Language.C99.Simple as C
@@ -50,7 +51,7 @@ mkbuffdecln sid ty xs = C.VarDecln (Just C.Static) cty name initvals
     name     = streamname sid
     cty      = C.Array (transtype ty) (Just $ C.LitInt $ fromIntegral buffsize)
     buffsize = length xs
-    initvals = Just $ C.InitArray $ constarray ty xs
+    initvals = Just $ C.InitList $ constarray ty xs
 
 -- | Make a C index variable and initialise it to 0.
 mkindexdecln :: Id -> C.Decln
@@ -148,7 +149,7 @@ mkstructdecln :: Struct a => Type a -> C.Decln
 mkstructdecln (Struct x) = C.TypeDecln struct
   where
     struct = C.TypeSpec $ C.StructDecln (Just $ typename x) fields
-    fields = map mkfield (toValues x)
+    fields = NonEmpty.fromList $ map mkfield (toValues x)
 
     mkfield :: Value a -> C.FieldDecln
     mkfield (Value ty field) = C.FieldDecln (transtype ty) (fieldname field)

--- a/copilot-c99/src/Copilot/Compile/C99/Translate.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Translate.hs
@@ -9,6 +9,8 @@ import Copilot.Core
 import Copilot.Compile.C99.Error (impossible)
 import Copilot.Compile.C99.Util
 
+import qualified Data.List.NonEmpty as NonEmpty
+
 import qualified Language.C99.Simple as C
 
 -- | Translates a Copilot Core expression into a C99 expression.
@@ -226,7 +228,7 @@ constty ty = case ty of
   Float     -> explicitty ty . C.LitFloat
   Double    -> explicitty ty . C.LitDouble
   Struct _  -> \v ->
-    C.InitVal (transtypename ty) (map constfieldinit (toValues v))
+    C.InitVal (transtypename ty) (NonEmpty.fromList $ map constfieldinit (toValues v))
   Array ty' -> \v ->
     C.InitVal (transtypename ty) (constarray ty' (arrayelems v))
 
@@ -254,7 +256,7 @@ constinit ty val = case ty of
   -- whole expression as an array of two int32_t's (as opposed to a nested
   -- array). This can either lead to compile-time errors (if you're lucky) or
   -- incorrect runtime semantics (if you're unlucky).
-  Array ty' -> C.InitArray $ constarray ty' $ arrayelems val
+  Array ty' -> C.InitList $ constarray ty' $ arrayelems val
 
   -- We use InitArray to initialize a struct because the syntax used for
   -- initializing arrays and structs is compatible. For instance, {1, 2} works
@@ -263,17 +265,18 @@ constinit ty val = case ty of
   -- (structs can also be initialized as { .a = 1, .b = 2}, but language-c99
   -- does not support such syntax and does not provide a specialized
   -- initialization construct for structs).
-  Struct _  -> C.InitArray $ map constfieldinit $ toValues val
+  Struct _  -> C.InitList $ NonEmpty.fromList $ map constfieldinit (toValues val)
   _         -> C.InitExpr $ constty ty val
 
 -- | Transform a Copilot Core struct field into a C99 initializer.
-constfieldinit :: Value a -> C.Init
-constfieldinit (Value ty (Field val)) = constinit ty val
+constfieldinit :: Value a -> C.InitItem
+constfieldinit (Value ty (Field val)) = C.InitItem Nothing $ constinit ty val
 
 -- | Transform a Copilot Array, based on the element values and their type,
 -- into a list of C99 initializer values.
-constarray :: Type a -> [a] -> [C.Init]
-constarray ty = map (constinit ty)
+constarray :: Type a -> [a] -> NonEmpty.NonEmpty C.InitItem
+constarray ty xs =
+  NonEmpty.fromList $ map (C.InitItem Nothing . constinit ty) xs
 
 -- | Explicitly cast a C99 value to a type.
 explicitty :: Type a -> C.Expr -> C.Expr

--- a/copilot-c99/src/Copilot/Compile/C99/Translate.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Translate.hs
@@ -262,9 +262,7 @@ constinit ty val = case ty of
   -- initializing arrays and structs is compatible. For instance, {1, 2} works
   -- both for initializing an int array of length 2 as well as a struct with
   -- two int fields, although the two expressions are conceptually different
-  -- (structs can also be initialized as { .a = 1, .b = 2}, but language-c99
-  -- does not support such syntax and does not provide a specialized
-  -- initialization construct for structs).
+  -- (structs can also be initialized as { .a = 1, .b = 2}.
   Struct _  -> C.InitList $ conststruct (toValues val)
   _         -> C.InitExpr $ constty ty val
 

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2022-05-15
+        * Updated to support language-c99-0.2.0. (#334)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)


### PR DESCRIPTION
The language-c99-simple library has been changed a bit, and requires one to provide a NonEmpty of initialiser values instead of a list (to better fit the C99 standard). The changes in this PR update copilot-c99 to reflect this requirement.
