### PR TITLE
Fix test case generation for shitfing operations. Refs #337.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2022-05-31
+        * Fix error in test case generation; enable CLI args in tests. (#337)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)

--- a/copilot-core/tests/Main.hs
+++ b/copilot-core/tests/Main.hs
@@ -2,8 +2,7 @@
 module Main where
 
 -- External imports
-import Data.Monoid    (mempty)
-import Test.Framework (Test, defaultMainWithOpts)
+import Test.Framework (Test, defaultMain)
 
 -- Internal library modules being tested
 import qualified Test.Copilot.Core.External
@@ -15,7 +14,7 @@ import qualified Test.Copilot.Core.Type.Show
 
 -- | Run all unit tests on copilot-core.
 main :: IO ()
-main = defaultMainWithOpts tests mempty
+main = defaultMain tests
 
 -- | All unit tests in copilot-core.
 tests :: [Test.Framework.Test]

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2022-05-31
+        * Fix error in test case generation; enable CLI args in tests. (#337)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)

--- a/copilot-language/tests/Main.hs
+++ b/copilot-language/tests/Main.hs
@@ -2,15 +2,14 @@
 module Main where
 
 -- External imports
-import Data.Monoid    (mempty)
-import Test.Framework (Test, defaultMainWithOpts)
+import Test.Framework (Test, defaultMain)
 
 -- Internal imports
 import qualified Test.Copilot.Language.Reify
 
 -- | Run all unit tests on copilot-language.
 main :: IO ()
-main = defaultMainWithOpts tests mempty
+main = defaultMain tests
 
 -- | All unit tests in copilot-language.
 tests :: [Test.Framework.Test]

--- a/copilot-language/tests/Test/Copilot/Language/Reify.hs
+++ b/copilot-language/tests/Test/Copilot/Language/Reify.hs
@@ -459,27 +459,42 @@ arbitraryBitsExpr =
 arbitraryBitsIntegralExpr :: (Arbitrary t, Typed t, Bits t, Integral t)
                           => Gen (Stream t, [t])
 arbitraryBitsIntegralExpr =
-  -- We use frequency instead of oneof because the random expression generator
-  -- seems to generate expressions that are too large and the test fails due
-  -- to running out of memory.
-  frequency
-    [ (10, arbitraryConst)
+      -- We use frequency instead of oneof because the random expression
+      -- generator seems to generate expressions that are too large and the
+      -- test fails due to running out of memory.
+      frequency
+        [ (10, arbitraryConst)
 
-    , (2, apply1 <$> arbitraryNumOp1 <*> arbitraryBitsIntegralExpr)
+        , (2, apply1 <$> arbitraryNumOp1 <*> arbitraryBitsIntegralExpr)
 
-    , (1, apply2 <$> arbitraryNumOp2
-                 <*> arbitraryBitsIntegralExpr
-                 <*> arbitraryBitsIntegralExpr)
+        , (1, apply2 <$> arbitraryNumOp2
+                     <*> arbitraryBitsIntegralExpr
+                     <*> arbitraryBitsIntegralExpr)
 
-    , (5, apply2 <$> arbitraryBitsIntegralOp2
-                 <*> arbitraryBitsIntegralExpr
-                 <*> arbitraryBitsIntegralExpr)
+        , (5, apply2 <$> arbitraryBitsIntegralOp2
+                     <*> arbitraryBitsIntegralExpr
+                     <*> arbitraryBitsIntegralExprConstPos)
 
-    , (1, apply3 <$> arbitraryITEOp3
-                 <*> arbitraryBoolExpr
-                 <*> arbitraryBitsIntegralExpr
-                 <*> arbitraryBitsIntegralExpr)
-    ]
+        , (1, apply3 <$> arbitraryITEOp3
+                     <*> arbitraryBoolExpr
+                     <*> arbitraryBitsIntegralExpr
+                     <*> arbitraryBitsIntegralExpr)
+        ]
+  where
+
+    -- Generator for constant bit integral expressions that, when converted to
+    -- type 't', result in a positive number. We use a constant generator, as
+    -- opposed to a generator based on the more comprehensive
+    -- arbitraryBitsIntegralExpr, because the latter runs out of memory easily
+    -- when nested and filtered with suchThat.
+    arbitraryBitsIntegralExprConstPos =
+        (\v -> (Copilot.constant v, repeat v)) <$> intThatFits
+      where
+        -- In this context:
+        --
+        -- intThatFits :: Gen t
+        intThatFits =
+          suchThat arbitrary ((> 0) . (\x -> (fromIntegral x) :: Int))
 
 -- ** Operators
 


### PR DESCRIPTION
This PR modifies the `copilot-core` and `copilot-language` tests so that streams where `<<` and `>>` are applied pointwise only use positive numbers for the second argument.

It also modifies the test so that the test seed can be passed as argument, which is necessary to reproduce the bug.