### PR TITLE
Enable tests in CI script. Refs #329.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,8 @@ before_install:
 
 script:
   - cabal v2-install --lib copilot
+
+  # Run tests only on GHC 8.10.4
+  #
+  # Only libraries with tests are listed below or the v2-test command fails.
+  - if [ "${GHCVER}" == "8.10.4" ]; then cabal v2-test -j1 copilot-core copilot-language; fi

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2022-05-31
+        * Run tests in CI. (#329)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)


### PR DESCRIPTION
This commit enables tests in the CI script for one version of GHC that the script is testing copilot with.

The rests are executed with `-j1` so that they produced more detailed logs.

Tests are only enabled for those packages that actually have tests, since it fails otherwise. This differs slightly from the solution proposed in #329 (enabling tests for all copilot packages).