### PR TITLE
`copilot-c99`: Pass structs by reference, not by value. Refs #305.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,6 +1,7 @@
-2022-06-11
+2022-06-15
         * Remove unnecessary dependencies from Cabal package. (#323)
         * Remove duplicated compiler option. (#328)
+        * Pass structs by reference, not value, in handlers. (#305)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -157,7 +157,15 @@ compileh cSettings spec = C.TransUnit declns []
           where
             cty    = C.TypeSpec C.Void
             params = map mkparam $ zip (argnames name) args
-            mkparam (name, UExpr ty _) = C.Param (transtype ty) name
+            mkparam (name, UExpr ty _) = C.Param (mkParamTy ty) name
+
+            -- Special case for Struct, to pass struct arguments by reference.
+            -- Arrays are also passed by reference, but using C's array type
+            -- does that automatically.
+            mkParamTy ty =
+              case ty of
+                Struct _ -> C.Ptr (transtype ty)
+                _        -> transtype ty
 
     -- Declaration for the step function.
     stepdecln :: C.Decln

--- a/copilot-c99/src/Copilot/Compile/C99/Util.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Util.hs
@@ -55,9 +55,18 @@ guardname name = name ++ "_guard"
 argname :: String -> Int -> String
 argname name n = name ++ "_arg" ++ show n
 
+-- | Turn a handler function name into a name for a temporary variable for a
+-- handler argument.
+argTempName :: String -> Int -> String
+argTempName name n = name ++ "_arg_temp" ++ show n
+
 -- | Enumerate all argument names based on trigger name.
 argnames :: String -> [String]
 argnames base = [aname | n <- [0..], let aname = argname base n]
+
+-- | Enumerate all temporary variable names based on handler function name.
+argTempNames :: String -> [String]
+argTempNames base = map (argTempName base) [0..]
 
 -- | Define a C expression that calls a function with arguments.
 funcall :: C.Ident -> [C.Expr] -> C.Expr


### PR DESCRIPTION
Previously, handlers with struct arguments would always pass the structs by value. For example, you might have a handler like this:

```c
void handle_ex(struct s ss) { ... }
```

This patch changes `copilot-c99`'s treatment of struct arguments so that they are also passed by reference. The example above will now look like this:

```c
void handle_ex(struct s *ss) { ... }
```

Making this happen requires changing code in two key places:

* In `Copilot.Compile.C99.Compile.compileh`, there is now a special case for `Struct`-typed arguments that adds a pointer to the argument type.
* In `Copilot.Compile.C99.CodeGen.mkstep`, there is now some pipe-fitting code to ensure that when the handler is invoked, it is given references to structs rather than raw struct values. This is accomplished by generating temporary variables for each of the handler's arguments, assigning them as appropriate, and then passing the temporary variables as arguments to the handler. In the particular case of a struct-typed temporary variable, C's `&` operator is used to obtain a reference to the variable. For example, the `handler_ex` function above would be invoked from the `step()` function in roughly the following fashion:

  ```c
  void step() {
    if (handler_guard()) {
      struct s handler_arg_temp = handler_arg();
      handler_ex(&handler_arg_temp);
    }
  }
  ```

  Assigning the result of `handler_arg()` to a temporary variable ensures that the struct value is defensively copied before being passed to the handler.