### PR TITLE
`copilot-libraries`: Remove unnecessary dependencies. Refs #327.

### DIFF
--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2022-06-02
+        * Remove unnecessary dependencies from Cabal package. (#327)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -38,9 +38,7 @@ library
 
   build-depends: base             >= 4.9 && < 5
 
-               , array            >= 0.5 && < 0.6
                , containers       >= 0.4 && < 0.7
-               , data-reify       >= 0.6 && < 0.7
                , mtl              >= 2.0 && < 2.3
                , parsec           >= 2.0 && < 3.2
                , copilot-language >= 3.9 && < 3.10


### PR DESCRIPTION
Remove `data-reify` and `array` from the `build-depends` field in the Cabal file, since they are not used.