### PR TITLE
`copilot-theorem`: Remove unnecessary dependencies. Refs #326.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,7 @@
-2022-06-01
+2022-06-09
         * Remove comment from cabal file. (#325)
+        * Remove unnecessary dependencies from Cabal package. (#326)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -41,13 +41,11 @@ library
                             -fcontext-stack=100
 
   build-depends           : base          >= 4.9 && < 5
-                          , ansi-terminal >= 0.8 && < 0.10
                           , bimap         >= 0.3 && < 0.4
                           , bv-sized      >= 1.0.2 && < 1.1
                           , containers    >= 0.4 && < 0.7
                           , data-default  >= 0.7 && < 0.8
                           , directory     >= 1.3 && < 1.4
-                          , filepath      >= 1.4.2 && < 1.5
                           , libBF         >= 0.6.2 && < 0.7
                           , mtl           >= 2.0 && < 2.3
                           , panic         >= 0.4.0 && < 0.5


### PR DESCRIPTION
Remove `ansi-terminal` and `filepath` from the `build-depends` field in the Cabal file, since they are not used.