### PR TITLE
`copilot-c99`: Remove unnecessary dependencies. Refs #323.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2022-06-10
+        * Remove unnecessary dependencies from Cabal package. (#323)
+
 2022-05-06
         * Version bump (3.9). (#320)
         * Compliance with style guide (partial). (#316)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -44,7 +44,6 @@ library
   -- internal modules.
   ghc-options             : -Wall -fwarn-tabs -Wno-deprecations
   build-depends           : base                >= 4.9 && < 5
-                          , containers          >= 0.4 && < 0.7
                           , directory           >= 1.3 && < 1.4
                           , filepath            >= 1.4 && < 1.5
                           , mtl                 >= 2.2 && < 2.3
@@ -52,7 +51,6 @@ library
 
                           , copilot-core        >= 3.9   && < 3.10
                           , language-c99        >= 0.1.1 && < 0.2
-                          , language-c99-util   >= 0.1.1 && < 0.2
                           , language-c99-simple >= 0.1.1 && < 0.2
 
   exposed-modules         : Copilot.Compile.C99


### PR DESCRIPTION
Remove `containers` and `language-c99-util` from the `build-depends` field in the Cabal file, since they are not used, as prescribed in the proposed solution to #323.