### PR TITLE
`copilot-core`: Remove unnecessary dependencies. Refs #324.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,5 +1,6 @@
-2022-05-31
+2022-06-10
         * Fix error in test case generation; enable CLI args in tests. (#337)
+        * Remove unnecessary dependencies from Cabal package. (#324)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -45,7 +45,6 @@ library
   build-depends:
     base       >= 4.9 && < 5,
     pretty     >= 1.0 && < 1.2,
-    mtl        >= 2.0 && < 2.3,
     dlist
 
   exposed-modules:


### PR DESCRIPTION
Remove `mtl` from the `build-depends` field in the Cabal file, since they are not used, as prescribed in the proposed solution to #324.