### PR TITLE
`copilot-core`: Deprecate module `Copilot.Core.External`. Refs #322.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,6 +1,7 @@
 2022-06-10
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove unnecessary dependencies from Cabal package. (#324)
+        * Deprecate Copilot.Core.External. (#322)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/src/Copilot/Core.hs
+++ b/copilot-core/src/Copilot/Core.hs
@@ -19,6 +19,10 @@
 -- ("Copilot.Core.PrettyPrint").
 
 {-# LANGUAGE Safe #-}
+-- The following warning is enabled in this module so that the import of
+-- Copilot.Core.External does not give rise to a warning. It can be removed
+-- when that module is removed from the implementation.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Copilot.Core
   ( module Copilot.Core.Expr
@@ -32,7 +36,7 @@ module Copilot.Core
   ) where
 
 import Copilot.Core.Expr
-import Copilot.Core.External
+import Copilot.Core.External -- See GHC flag enabled above
 import Copilot.Core.Operators
 import Copilot.Core.Spec
 import Copilot.Core.Type

--- a/copilot-core/src/Copilot/Core/External.hs
+++ b/copilot-core/src/Copilot/Core/External.hs
@@ -6,6 +6,7 @@
 
 -- | Internal Copilot Core representation of Copilot externs.
 module Copilot.Core.External
+  {-# DEPRECATED "This module is deprecated in Copilot 3.10." #-}
   ( ExtVar (..)
   , externVars
   ) where

--- a/copilot-core/tests/Test/Copilot/Core/External.hs
+++ b/copilot-core/tests/Test/Copilot/Core/External.hs
@@ -1,3 +1,7 @@
+-- The following warning is enabled in this module so that the import of
+-- Copilot.Core.External does not give rise to a warning.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- | Test copilot-core:Copilot.Core.External.
 module Test.Copilot.Core.External where
 


### PR DESCRIPTION
Deprecate the unused module `Copilot.Core.External` and add disable deprecation warnings in any modules that (temporarily) import it, as prescribed in the solution to #322.