### PR TITLE
Remove duplicated compiler flag. Refs #328.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
-2022-06-10
+2022-06-11
         * Remove unnecessary dependencies from Cabal package. (#323)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -42,7 +42,7 @@ library
   -- https://github.com/Copilot-Language/copilot/issues/237
   -- It should be removed in a future version, when this library hides
   -- internal modules.
-  ghc-options             : -Wall -fwarn-tabs -Wno-deprecations
+  ghc-options             : -Wall -Wno-deprecations
   build-depends           : base                >= 4.9 && < 5
                           , directory           >= 1.3 && < 1.4
                           , filepath            >= 1.4 && < 1.5

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,7 +1,8 @@
-2022-06-10
+2022-06-11
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove unnecessary dependencies from Cabal package. (#324)
         * Deprecate Copilot.Core.External. (#322)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -39,7 +39,6 @@ library
 
   ghc-options:
     -Wall
-    -fwarn-tabs
     -fno-warn-orphans
 
   build-depends:

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,5 +1,6 @@
-2022-05-31
+2022-06-11
         * Fix error in test case generation; enable CLI args in tests. (#337)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -71,7 +71,6 @@ library
                  , System.Mem.StableName.Map
                  , Copilot.Language.Error
   ghc-options:
-    -fwarn-tabs
     -Wall
 
 test-suite unit-tests

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,5 +1,6 @@
-2022-06-02
+2022-06-11
         * Remove unnecessary dependencies from Cabal package. (#327)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -56,5 +56,4 @@ library
     , Copilot.Library.MTL
 
   ghc-options:
-    -fwarn-tabs
     -Wall

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,6 +1,7 @@
-2022-06-09
+2022-06-11
         * Remove comment from cabal file. (#325)
         * Remove unnecessary dependencies from Cabal package. (#326)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -34,7 +34,7 @@ library
   default-language        : Haskell2010
   hs-source-dirs          : src
 
-  ghc-options             : -Wall -fwarn-tabs
+  ghc-options             : -Wall
                             -fno-warn-name-shadowing
                             -fno-warn-unused-binds
                             -fno-warn-missing-signatures

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,5 +1,6 @@
-2022-05-31
+2022-06-11
         * Run tests in CI. (#329)
+        * Remove duplicated compiler option. (#328)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -44,7 +44,6 @@ library
     default-language:  Haskell2010
     ghc-options:
       -Wall
-      -fwarn-tabs
       -fno-warn-orphans
     build-depends:
                        base                 >= 4.9  && < 5


### PR DESCRIPTION
Remove option -fwarn-tabs from all cabal files, as prescribed in the solution proposed for #328.