### PR TITLE
`copilot-core`: Hide deprecated type `ShowWit`. Refs #348.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -3,6 +3,7 @@
         * Remove unnecessary dependencies from Cabal package. (#324)
         * Deprecate Copilot.Core.External. (#322)
         * Remove duplicated compiler option. (#328)
+        * Hide type Copilot.Core.Type.Show.ShowWit. (#348)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/src/Copilot/Core/Type/Show.hs
+++ b/copilot-core/src/Copilot/Core/Type/Show.hs
@@ -13,45 +13,6 @@ module Copilot.Core.Type.Show
 
 import Copilot.Core.Type
 
--- | Witness datatype for showing a value, used by 'showWithType'.
-data ShowWit a = Show a => ShowWit
-
--- | Turn a type into a show witness.
-showWit :: Type a -> ShowWit a
-showWit t =
-  case t of
-    Bool   -> ShowWit
-    Int8   -> ShowWit
-    Int16  -> ShowWit
-    Int32  -> ShowWit
-    Int64  -> ShowWit
-    Word8  -> ShowWit
-    Word16 -> ShowWit
-    Word32 -> ShowWit
-    Word64 -> ShowWit
-    Float  -> ShowWit
-    Double -> ShowWit
-    Array t -> ShowWit
-    Struct t -> ShowWit
-
--- | Show Copilot Core type.
-showType :: Type a -> String
-showType t =
-  case t of
-    Bool   -> "Bool"
-    Int8   -> "Int8"
-    Int16  -> "Int16"
-    Int32  -> "Int32"
-    Int64  -> "Int64"
-    Word8  -> "Word8"
-    Word16 -> "Word16"
-    Word32 -> "Word32"
-    Word64 -> "Word64"
-    Float  -> "Float"
-    Double -> "Double"
-    Array t -> "Array " ++ showType t
-    Struct t -> "Struct"
-
 -- Are we proving equivalence with a C backend, in which case we want to show
 -- Booleans as '0' and '1'.
 
@@ -73,3 +34,44 @@ showWithType showT t x =
   where
   sw = case showWit t of
          ShowWit -> show x
+
+-- | Show Copilot Core type.
+showType :: Type a -> String
+showType t =
+  case t of
+    Bool   -> "Bool"
+    Int8   -> "Int8"
+    Int16  -> "Int16"
+    Int32  -> "Int32"
+    Int64  -> "Int64"
+    Word8  -> "Word8"
+    Word16 -> "Word16"
+    Word32 -> "Word32"
+    Word64 -> "Word64"
+    Float  -> "Float"
+    Double -> "Double"
+    Array t -> "Array " ++ showType t
+    Struct t -> "Struct"
+
+-- * Auxiliary show instance
+
+-- | Witness datatype for showing a value, used by 'showWithType'.
+data ShowWit a = Show a => ShowWit
+
+-- | Turn a type into a show witness.
+showWit :: Type a -> ShowWit a
+showWit t =
+  case t of
+    Bool   -> ShowWit
+    Int8   -> ShowWit
+    Int16  -> ShowWit
+    Int32  -> ShowWit
+    Int64  -> ShowWit
+    Word8  -> ShowWit
+    Word16 -> ShowWit
+    Word32 -> ShowWit
+    Word64 -> ShowWit
+    Float  -> ShowWit
+    Double -> ShowWit
+    Array t -> ShowWit
+    Struct t -> ShowWit

--- a/copilot-core/src/Copilot/Core/Type/Show.hs
+++ b/copilot-core/src/Copilot/Core/Type/Show.hs
@@ -6,8 +6,7 @@
 
 -- | Show Copilot Core types and typed values.
 module Copilot.Core.Type.Show
-  ( ShowWit (..)
-  , showWithType
+  ( showWithType
   , ShowType(..)
   , showType
   ) where
@@ -15,7 +14,6 @@ module Copilot.Core.Type.Show
 import Copilot.Core.Type
 
 -- | Witness datatype for showing a value, used by 'showWithType'.
-{-# DEPRECATED ShowWit "This type is deprecated in Copilot 3.7." #-}
 data ShowWit a = Show a => ShowWit
 
 -- | Turn a type into a show witness.


### PR DESCRIPTION
Hide a type `ShowWit`, deprecated in Copilot 3.7, as prescribed in the solution proposed for #348.

Re-organize module to reflect that type and function to operate with it are purely auxiliary.