### PR TITLE
Deprecate module Copilot.Core.Type.Show. Refs #330.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,9 +1,10 @@
-2022-06-11
+2022-06-12
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove unnecessary dependencies from Cabal package. (#324)
         * Deprecate Copilot.Core.External. (#322)
         * Remove duplicated compiler option. (#328)
         * Hide type Copilot.Core.Type.Show.ShowWit. (#348)
+        * Deprecate Copilot.Core.Type.Show. (#330)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -67,6 +67,7 @@ library
 
     Copilot.Core.Error
     Copilot.Core.Interpret.Render
+    Copilot.Core.Type.ShowInternal
 
 test-suite unit-tests
   type:

--- a/copilot-core/src/Copilot/Core/Interpret.hs
+++ b/copilot-core/src/Copilot/Core/Interpret.hs
@@ -12,7 +12,7 @@ module Copilot.Core.Interpret
 import Copilot.Core
 import Copilot.Core.Interpret.Eval
 import Copilot.Core.Interpret.Render
-import Copilot.Core.Type.Show (ShowType(..))
+import Copilot.Core.Type.ShowInternal (ShowType(..))
 
 -- | Output format for the results of a Copilot spec interpretation.
 data Format = Table | CSV

--- a/copilot-core/src/Copilot/Core/Interpret/Eval.hs
+++ b/copilot-core/src/Copilot/Core/Interpret/Eval.hs
@@ -12,6 +12,7 @@ module Copilot.Core.Interpret.Eval
   , Output
   , ExecTrace (..)
   , eval
+  , ShowType (..)
   ) where
 
 import Copilot.Core                   (Expr (..), Field (..), Id, Name,

--- a/copilot-core/src/Copilot/Core/Interpret/Eval.hs
+++ b/copilot-core/src/Copilot/Core/Interpret/Eval.hs
@@ -14,13 +14,14 @@ module Copilot.Core.Interpret.Eval
   , eval
   ) where
 
-import Copilot.Core           (Expr (..), Field (..), Id, Name, Observer (..),
-                               Op1 (..), Op2 (..), Op3 (..), Spec, Stream (..),
-                               Trigger (..), Type (Struct), UExpr (..),
-                               arrayelems, specObservers, specStreams,
-                               specTriggers)
-import Copilot.Core.Error     (badUsage)
-import Copilot.Core.Type.Show (ShowType, showWithType)
+import Copilot.Core                   (Expr (..), Field (..), Id, Name,
+                                       Observer (..), Op1 (..), Op2 (..),
+                                       Op3 (..), Spec, Stream (..),
+                                       Trigger (..), Type (Struct), UExpr (..),
+                                       arrayelems, specObservers, specStreams,
+                                       specTriggers)
+import Copilot.Core.Error             (badUsage)
+import Copilot.Core.Type.ShowInternal (ShowType (..), showWithType)
 
 import           Prelude hiding (id)
 import qualified Prelude as P

--- a/copilot-core/src/Copilot/Core/PrettyDot.hs
+++ b/copilot-core/src/Copilot/Core/PrettyDot.hs
@@ -11,7 +11,7 @@ module Copilot.Core.PrettyDot
   ) where
 
 import Copilot.Core
-import Copilot.Core.Type.Show (showWithType, ShowType(..), showType)
+import Copilot.Core.Type.ShowInternal (showWithType, ShowType(..), showType)
 import Prelude hiding (id, (<>))
 import Text.PrettyPrint.HughesPJ
 import Data.List (intersperse)

--- a/copilot-core/src/Copilot/Core/PrettyPrint.hs
+++ b/copilot-core/src/Copilot/Core/PrettyPrint.hs
@@ -12,7 +12,7 @@ module Copilot.Core.PrettyPrint
 
 import Copilot.Core
 import Copilot.Core.Error (impossible)
-import Copilot.Core.Type.Show (showWithType, ShowType(..), showType)
+import Copilot.Core.Type.ShowInternal (showWithType, ShowType(..), showType)
 import Prelude hiding (id, (<>))
 import Text.PrettyPrint.HughesPJ
 import Data.List (intersperse)

--- a/copilot-core/src/Copilot/Core/Type/Show.hs
+++ b/copilot-core/src/Copilot/Core/Type/Show.hs
@@ -2,6 +2,7 @@
 
 -- | Show Copilot Core types and typed values.
 module Copilot.Core.Type.Show
+  {-# DEPRECATED "This module is deprecated in Copilot 3.10." #-}
   ( showWithType
   , ShowType(..)
   , showType

--- a/copilot-core/src/Copilot/Core/Type/Show.hs
+++ b/copilot-core/src/Copilot/Core/Type/Show.hs
@@ -1,9 +1,5 @@
 -- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
 
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE Safe                      #-}
-
 -- | Show Copilot Core types and typed values.
 module Copilot.Core.Type.Show
   ( showWithType
@@ -11,67 +7,4 @@ module Copilot.Core.Type.Show
   , showType
   ) where
 
-import Copilot.Core.Type
-
--- Are we proving equivalence with a C backend, in which case we want to show
--- Booleans as '0' and '1'.
-
--- | Target language for showing a typed value. Used to adapt the
--- representation of booleans.
-data ShowType = C | Haskell
-
--- | Show a value. The representation depends on the type and the target
--- language. Booleans are represented differently depending on the backend.
-showWithType :: ShowType -> Type a -> a -> String
-showWithType showT t x =
-  case showT of
-    C         -> case t of
-                   Bool -> if x then "1" else "0"
-                   _    -> sw
-    Haskell   -> case t of
-                   Bool -> if x then "true" else "false"
-                   _    -> sw
-  where
-  sw = case showWit t of
-         ShowWit -> show x
-
--- | Show Copilot Core type.
-showType :: Type a -> String
-showType t =
-  case t of
-    Bool   -> "Bool"
-    Int8   -> "Int8"
-    Int16  -> "Int16"
-    Int32  -> "Int32"
-    Int64  -> "Int64"
-    Word8  -> "Word8"
-    Word16 -> "Word16"
-    Word32 -> "Word32"
-    Word64 -> "Word64"
-    Float  -> "Float"
-    Double -> "Double"
-    Array t -> "Array " ++ showType t
-    Struct t -> "Struct"
-
--- * Auxiliary show instance
-
--- | Witness datatype for showing a value, used by 'showWithType'.
-data ShowWit a = Show a => ShowWit
-
--- | Turn a type into a show witness.
-showWit :: Type a -> ShowWit a
-showWit t =
-  case t of
-    Bool   -> ShowWit
-    Int8   -> ShowWit
-    Int16  -> ShowWit
-    Int32  -> ShowWit
-    Int64  -> ShowWit
-    Word8  -> ShowWit
-    Word16 -> ShowWit
-    Word32 -> ShowWit
-    Word64 -> ShowWit
-    Float  -> ShowWit
-    Double -> ShowWit
-    Array t -> ShowWit
-    Struct t -> ShowWit
+import Copilot.Core.Type.ShowInternal (ShowType (..), showType, showWithType)

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -1,0 +1,77 @@
+-- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
+
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE Safe                      #-}
+
+-- | Show Copilot Core types and typed values.
+module Copilot.Core.Type.ShowInternal
+  ( showWithType
+  , ShowType(..)
+  , showType
+  ) where
+
+import Copilot.Core.Type
+
+-- Are we proving equivalence with a C backend, in which case we want to show
+-- Booleans as '0' and '1'.
+
+-- | Target language for showing a typed value. Used to adapt the
+-- representation of booleans.
+data ShowType = C | Haskell
+
+-- | Show a value. The representation depends on the type and the target
+-- language. Booleans are represented differently depending on the backend.
+showWithType :: ShowType -> Type a -> a -> String
+showWithType showT t x =
+  case showT of
+    C         -> case t of
+                   Bool -> if x then "1" else "0"
+                   _    -> sw
+    Haskell   -> case t of
+                   Bool -> if x then "true" else "false"
+                   _    -> sw
+  where
+  sw = case showWit t of
+         ShowWit -> show x
+
+-- | Show Copilot Core type.
+showType :: Type a -> String
+showType t =
+  case t of
+    Bool   -> "Bool"
+    Int8   -> "Int8"
+    Int16  -> "Int16"
+    Int32  -> "Int32"
+    Int64  -> "Int64"
+    Word8  -> "Word8"
+    Word16 -> "Word16"
+    Word32 -> "Word32"
+    Word64 -> "Word64"
+    Float  -> "Float"
+    Double -> "Double"
+    Array t -> "Array " ++ showType t
+    Struct t -> "Struct"
+
+-- * Auxiliary show instance
+
+-- | Witness datatype for showing a value, used by 'showWithType'.
+data ShowWit a = Show a => ShowWit
+
+-- | Turn a type into a show witness.
+showWit :: Type a -> ShowWit a
+showWit t =
+  case t of
+    Bool   -> ShowWit
+    Int8   -> ShowWit
+    Int16  -> ShowWit
+    Int32  -> ShowWit
+    Int64  -> ShowWit
+    Word8  -> ShowWit
+    Word16 -> ShowWit
+    Word32 -> ShowWit
+    Word64 -> ShowWit
+    Float  -> ShowWit
+    Double -> ShowWit
+    Array t -> ShowWit
+    Struct t -> ShowWit

--- a/copilot-core/tests/Test/Copilot/Core/Interpret/Eval.hs
+++ b/copilot-core/tests/Test/Copilot/Core/Interpret/Eval.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE ExistentialQuantification #-}
+-- The following warning is disabled in this module so that the import of
+-- Copilot.Core.Type.Show does not give rise to a warning.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- | Test copilot-core:Copilot.Core.Interpret.Eval.
 --
 -- The gist of this evaluation is in 'SemanticsP' and 'checkSemanticsP' which

--- a/copilot-core/tests/Test/Copilot/Core/Type/Show.hs
+++ b/copilot-core/tests/Test/Copilot/Core/Type/Show.hs
@@ -1,3 +1,7 @@
+-- The following warning is disnabled in this module so that the import of
+-- Copilot.Core.Type.Show does not give rise to a warning.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- | Test copilot-core:Copilot.Core.Type.Show.
 module Test.Copilot.Core.Type.Show where
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,6 +1,7 @@
-2022-06-11
+2022-06-12
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove duplicated compiler option. (#328)
+        * Adjust imports due to deprecation. (#330)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-language/tests/Test/Copilot/Language/Reify.hs
+++ b/copilot-language/tests/Test/Copilot/Language/Reify.hs
@@ -36,8 +36,8 @@ import           Copilot.Language.Stream             (Stream)
 import qualified Copilot.Language.Stream             as Copilot
 
 -- Internal imports: functions needed to test after reification
-import Copilot.Core.Type.Show      (ShowType (Haskell))
-import Copilot.Core.Interpret.Eval (ExecTrace (interpObservers), eval)
+import Copilot.Core.Interpret.Eval (ExecTrace (interpObservers),
+                                    ShowType (Haskell), eval)
 
 -- Internal imports: auxiliary functions
 import Test.Extra (apply1, apply2, apply3)


### PR DESCRIPTION
Deprecate the module Copilot.Core.Type.Show, creating an intermediate module to hold the actual implementation, and adjust exports and imports accordingly, as prescribed in the solution to #330.