### PR TITLE
`copilot-language`: Fix typos in Copilot.Language.Interpret. Refs #331.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,7 +1,8 @@
-2022-06-12
+2022-06-13
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove duplicated compiler option. (#328)
         * Adjust imports due to deprecation. (#330)
+        * Fix typos in Copilot.Language.Interpret. (#331)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-language/src/Copilot/Language/Interpret.hs
+++ b/copilot-language/src/Copilot/Language/Interpret.hs
@@ -1,8 +1,8 @@
 -- Copyright (c) 2011 National Institute of Aerospace / Galois, Inc.
 
--- | This module implements two interpreters, which may be used to simulated or
--- executed Copilot specifications on a computer to understand their behavior
--- to debug possible errors.
+-- | This module implements two interpreters, which may be used to simulate or
+-- execute Copilot specifications on a computer to understand their behavior to
+-- debug possible errors.
 --
 -- The interpreters included vary in how the present the results to the user.
 -- One of them uses a format (csv) that may be more machine-readable, while the


### PR DESCRIPTION
Fix the typos in the module documentation as described in the solution proposed for #331.  