### PR TITLE
`copilot`: Fix typos. Refs #352.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,6 +1,7 @@
-2022-06-11
+2022-06-17
         * Run tests in CI. (#329)
         * Remove duplicated compiler option. (#328)
+        * Fix typos in README and Heater example. (#352)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -83,7 +83,7 @@ of the main repository.
 -- This is a simple example with basic usage. It implements a simple home
 -- heating system: It heats when temp gets too low, and stops when it is high
 -- enough. It read temperature as a byte (range -50C to 100C) and translates
--- this to Celcius.
+-- this to Celsius.
 
 module Heater where
 
@@ -96,7 +96,7 @@ import Prelude hiding ((>), (<), div)
 temp :: Stream Word8
 temp = extern "temperature" Nothing
 
--- Calculate temperature in Celcius.
+-- Calculate temperature in Celsius.
 -- We need to cast the Word8 to a Float. Note that it is an unsafeCast, as there
 -- is no direct relation between Word8 and Float.
 ctemp :: Stream Float

--- a/copilot/examples/Heater.hs
+++ b/copilot/examples/Heater.hs
@@ -3,7 +3,7 @@
 -- This is a simple example with basic usage. It implements a simple home
 -- heating system: It heats when temp gets too low, and stops when it is high
 -- enough. It read temperature as a byte (range -50C to 100C) and translates
--- this to Celcius.
+-- this to Celsius.
 
 module Main where
 
@@ -16,7 +16,7 @@ import Prelude hiding ((>), (<), div)
 temp :: Stream Word8
 temp = extern "temperature" Nothing
 
--- Calculate temperature in Celcius.
+-- Calculate temperature in Celsius.
 -- We need to cast the Word8 to a Float. Note that it is an unsafeCast, as there
 -- is no direct relation between Word8 and Float.
 ctemp :: Stream Float


### PR DESCRIPTION
Fix spelling of Celsius in the README and the Heater example as described in the solution proposed for #352.