### PR TITLE
Relax version bounds of dependencies. Refs #335.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - git submodule update --remote
 
 script:
-  - cabal v2-install --lib copilot
+  - travis_wait 30 cabal v2-install --lib copilot
 
   # Run tests only on GHC 8.10.4
   #

--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,7 +1,8 @@
-2022-06-15
+2022-07-04
         * Remove unnecessary dependencies from Cabal package. (#323)
         * Remove duplicated compiler option. (#328)
         * Pass structs by reference, not value, in handlers. (#305)
+        * Relax version bounds of dependencies. (#335)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -46,7 +46,7 @@ library
   build-depends           : base                >= 4.9 && < 5
                           , directory           >= 1.3 && < 1.4
                           , filepath            >= 1.4 && < 1.5
-                          , mtl                 >= 2.2 && < 2.3
+                          , mtl                 >= 2.2 && < 2.4
                           , pretty              >= 1.1 && < 1.2
 
                           , copilot-core        >= 3.9   && < 3.10

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,6 +1,7 @@
-2022-06-11
+2022-07-04
         * Remove unnecessary dependencies from Cabal package. (#327)
         * Remove duplicated compiler option. (#328)
+        * Relax version bounds of dependencies. (#335)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -39,7 +39,7 @@ library
   build-depends: base             >= 4.9 && < 5
 
                , containers       >= 0.4 && < 0.7
-               , mtl              >= 2.0 && < 2.3
+               , mtl              >= 2.0 && < 2.4
                , parsec           >= 2.0 && < 3.2
                , copilot-language >= 3.9 && < 3.10
 

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,7 +1,8 @@
-2022-06-11
+2022-07-04
         * Remove comment from cabal file. (#325)
         * Remove unnecessary dependencies from Cabal package. (#326)
         * Remove duplicated compiler option. (#328)
+        * Relax version bounds of dependencies. (#335)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -47,7 +47,7 @@ library
                           , data-default  >= 0.7 && < 0.8
                           , directory     >= 1.3 && < 1.4
                           , libBF         >= 0.6.2 && < 0.7
-                          , mtl           >= 2.0 && < 2.3
+                          , mtl           >= 2.0 && < 2.4
                           , panic         >= 0.4.0 && < 0.5
                           , parsec        >= 2.0 && < 3.2
                           , parameterized-utils >= 2.1.1 && < 2.2

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -41,7 +41,7 @@ library
                             -fcontext-stack=100
 
   build-depends           : base          >= 4.9 && < 5
-                          , bimap         >= 0.3 && < 0.4
+                          , bimap         (>= 0.3 && < 0.4) || (>= 0.5 && < 0.6)
                           , bv-sized      >= 1.0.2 && < 1.1
                           , containers    >= 0.4 && < 0.7
                           , data-default  >= 0.7 && < 0.8

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -54,7 +54,7 @@ library
                           , pretty        >= 1.0 && < 1.2
                           , process       >= 1.6 && < 1.7
                           , random        >= 1.1 && < 1.3
-                          , transformers  >= 0.5 && < 0.6
+                          , transformers  >= 0.5 && < 0.7
                           , xml           >= 1.3 && < 1.4
                           , what4         >= 1.1 && < 1.4
 

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -53,7 +53,7 @@ library
                           , parameterized-utils >= 2.1.1 && < 2.2
                           , pretty        >= 1.0 && < 1.2
                           , process       >= 1.6 && < 1.7
-                          , random        >= 1.1 && < 1.2
+                          , random        >= 1.1 && < 1.3
                           , transformers  >= 0.5 && < 0.6
                           , xml           >= 1.3 && < 1.4
                           , what4         >= 1.1 && < 1.4

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -56,7 +56,7 @@ library
                           , random        >= 1.1 && < 1.2
                           , transformers  >= 0.5 && < 0.6
                           , xml           >= 1.3 && < 1.4
-                          , what4         >= 1.1 && < 1.3
+                          , what4         >= 1.1 && < 1.4
 
                           , copilot-core  >= 3.9 && < 3.10
 

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,7 +1,8 @@
-2022-06-17
+2022-07-04
         * Run tests in CI. (#329)
         * Remove duplicated compiler option. (#328)
         * Fix typos in README and Heater example. (#352)
+        * Relax version bounds of dependencies. (#335)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -47,7 +47,7 @@ library
       -fno-warn-orphans
     build-depends:
                        base                 >= 4.9  && < 5
-                     , optparse-applicative >= 0.14 && < 0.16
+                     , optparse-applicative >= 0.14 && < 0.18
                      , directory            >= 1.3  && < 1.4
                      , filepath             >= 1.4  && < 1.5
 


### PR DESCRIPTION
This commit relaxes the constraints on dependencies, as prescribed in the solution to #335.

Due to a bug in language-c99-simple, we choose not to support the latest version yet (and, consequently and transitively, we do not support GHC > 9.0 either). For all other direct dependencies, the latest version available on hackage is supported with this change.