### PR TITLE
Update / include repo locations, subdirs. Refs #333.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,8 +1,9 @@
-2022-07-04
+2022-07-07
         * Remove unnecessary dependencies from Cabal package. (#323)
         * Remove duplicated compiler option. (#328)
         * Pass structs by reference, not value, in handlers. (#305)
         * Relax version bounds of dependencies. (#335)
+        * Update repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -31,8 +31,8 @@ x-curation: uncurated
 
 source-repository head
     type:       git
-    location:   git://github.com/Copilot-Language/copilot.git
-    subdir:     lib/copilot-c99
+    location:   https://github.com/Copilot-Language/copilot.git
+    subdir:     copilot-c99
 
 library
   default-language        : Haskell2010

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,10 +1,11 @@
-2022-06-12
+2022-07-07
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove unnecessary dependencies from Cabal package. (#324)
         * Deprecate Copilot.Core.External. (#322)
         * Remove duplicated compiler option. (#328)
         * Hide type Copilot.Core.Type.Show.ShowWit. (#348)
         * Deprecate Copilot.Core.Type.Show. (#330)
+        * Update repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -29,7 +29,7 @@ x-curation: uncurated
 source-repository head
     type:       git
     location:   https://github.com/Copilot-Language/copilot.git
-    subdir:     lib/copilot-core
+    subdir:     copilot-core
 
 library
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,8 +1,9 @@
-2022-06-13
+2022-07-07
         * Fix error in test case generation; enable CLI args in tests. (#337)
         * Remove duplicated compiler option. (#328)
         * Adjust imports due to deprecation. (#330)
         * Fix typos in Copilot.Language.Interpret. (#331)
+        * Update repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -30,7 +30,7 @@ x-curation: uncurated
 source-repository head
     type:       git
     location:   https://github.com/Copilot-Language/copilot.git
-    subdir:     lib/copilot-language
+    subdir:     copilot-language
 
 library
   default-language: Haskell2010

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,7 +1,8 @@
-2022-07-04
+2022-07-07
         * Remove unnecessary dependencies from Cabal package. (#327)
         * Remove duplicated compiler option. (#328)
         * Relax version bounds of dependencies. (#335)
+        * Update repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -28,8 +28,8 @@ x-curation: uncurated
 
 source-repository head
     type:       git
-    location:   git://github.com/Copilot-Language/copilot.git
-    subdir:     lib/copilot-libraries
+    location:   https://github.com/Copilot-Language/copilot.git
+    subdir:     copilot-libraries
 
 library
   default-language: Haskell2010

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,8 +1,9 @@
-2022-07-04
+2022-07-07
         * Remove comment from cabal file. (#325)
         * Remove unnecessary dependencies from Cabal package. (#326)
         * Remove duplicated compiler option. (#328)
         * Relax version bounds of dependencies. (#335)
+        * Include repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -30,6 +30,11 @@ author                    : Jonathan Laurent
 
 x-curation: uncurated
 
+source-repository head
+    type:       git
+    location:   https://github.com/Copilot-Language/copilot.git
+    subdir:     copilot-theorem
+
 library
   default-language        : Haskell2010
   hs-source-dirs          : src

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,8 +1,9 @@
-2022-07-04
+2022-07-07
         * Run tests in CI. (#329)
         * Remove duplicated compiler option. (#328)
         * Fix typos in README and Heater example. (#352)
         * Relax version bounds of dependencies. (#335)
+        * Update repo info in cabal file. (#333)
 
 2022-05-06
         * Version bump (3.9). (#320)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -33,6 +33,7 @@ extra-source-files:
 source-repository head
     type:       git
     location:   https://github.com/Copilot-Language/copilot.git
+    subdir:     copilot
 
 flag examples
     description: Enable examples


### PR DESCRIPTION
Update repo locations to use https, adjust subdirs to match new repo organization, and add missing repo info to copilot-theorem's cabal package, as prescribed in solution proposed for #333.