### PR TITLE
`copilot-language`: deprecate `Copilot.Language.prettyPrint`. Refs #362.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2022-08-08
+        * Deprecate prettyPrint. (#362)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Fix error in test case generation; enable CLI args in tests. (#337)

--- a/copilot-language/src/Copilot/Language.hs
+++ b/copilot-language/src/Copilot/Language.hs
@@ -71,5 +71,6 @@ import Copilot.Language.Stream (Stream)
 
 -- | Transform a high-level Copilot Language specification into a low-level
 -- Copilot Core specification and pretty-print it to stdout.
+{-# DEPRECATED prettyPrint "This function is deprecated in Copilot 3.11." #-}
 prettyPrint :: Spec -> IO ()
 prettyPrint e = fmap PP.prettyPrint (reify e) >>= putStr


### PR DESCRIPTION
Fix the function `Copilot.Language.prettyPrint`, as prescribed in the solution proposed for https://github.com/Copilot-Language/copilot/issues/362.