### PR TITLE
`copilot-core`: deprecate `Copilot.Core.PrettyDot`. Refs #359.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2022-08-04
+        * Deprecate Copilot.Core.PrettyDot. (#359)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Fix error in test case generation; enable CLI args in tests. (#337)

--- a/copilot-core/src/Copilot/Core/PrettyDot.hs
+++ b/copilot-core/src/Copilot/Core/PrettyDot.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE Safe  #-}
 
 module Copilot.Core.PrettyDot
+  {-# DEPRECATED "This module is deprecated in Copilot 3.11." #-}
   ( prettyPrintDot
   , prettyPrintExprDot
   ) where


### PR DESCRIPTION
Fix the module `Copilot.Core.PrettyDot`, as prescribed in the solution proposed for #359.