### PR TITLE
`copilot-language`: implement `DynStableName` without `unsafeCoerce`. Refs #262.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,5 +1,6 @@
-2022-08-08
+2022-08-12
         * Deprecate prettyPrint. (#362)
+        * Reimplement DynStableName without unsafeCoerce. (#262)
 
 2022-07-07
         * Version bump (3.10). (#356)

--- a/copilot-language/src/System/Mem/StableName/Dynamic.hs
+++ b/copilot-language/src/System/Mem/StableName/Dynamic.hs
@@ -1,6 +1,7 @@
 -- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
 
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE Safe                      #-}
 
 module System.Mem.StableName.Dynamic
   ( DynStableName(..)
@@ -8,19 +9,19 @@ module System.Mem.StableName.Dynamic
   , makeDynStableName
   ) where
 
-import System.Mem.StableName (StableName, makeStableName, hashStableName)
-import Unsafe.Coerce (unsafeCoerce) -- XXX Not safe!
+import System.Mem.StableName (StableName, eqStableName, makeStableName,
+                              hashStableName)
 
-newtype DynStableName = DynStableName (StableName ())
+data DynStableName = forall a . DynStableName (StableName a)
 
 makeDynStableName :: a -> IO DynStableName
 makeDynStableName x =
   do
     stn <- makeStableName x
-    return (DynStableName (unsafeCoerce stn))
+    return (DynStableName stn)
 
 hashDynStableName :: DynStableName -> Int
 hashDynStableName (DynStableName sn) = hashStableName sn
 
 instance Eq DynStableName where
-  DynStableName sn1 == DynStableName sn2 = sn1 == sn2
+  DynStableName sn1 == DynStableName sn2 = eqStableName sn1 sn2


### PR DESCRIPTION
Remove unnecessary use of `unsafeCoerce` by reimplemeting `DynStableName` using an existential type, as prescribed in the solution proposed for #262.