### PR TITLE
`copilot-c99`: adapt to work with `language-c99-0.2` and `language-c99-simple-0.2.1`. Refs #371.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2022-08-23
+        * Update to support language-c99-0.2.0. (#371)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Remove unnecessary dependencies from Cabal package. (#323)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -50,8 +50,8 @@ library
                           , pretty              >= 1.1 && < 1.2
 
                           , copilot-core        >= 3.10  && < 3.11
-                          , language-c99        >= 0.1.1 && < 0.2
-                          , language-c99-simple >= 0.1.1 && < 0.2
+                          , language-c99        >= 0.2.0 && < 0.3
+                          , language-c99-simple >= 0.2.1 && < 0.3
 
   exposed-modules         : Copilot.Compile.C99
 

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -4,9 +4,10 @@
 -- | High-level translation of Copilot Core into C99.
 module Copilot.Compile.C99.CodeGen where
 
-import Control.Monad.State  (runState)
-import Data.List            (union, unzip4)
-import Data.Typeable        (Typeable)
+import           Control.Monad.State (runState)
+import           Data.List           (union, unzip4)
+import qualified Data.List.NonEmpty  as NonEmpty
+import           Data.Typeable       (Typeable)
 
 import qualified Language.C99.Simple as C
 
@@ -50,7 +51,7 @@ mkbuffdecln sid ty xs = C.VarDecln (Just C.Static) cty name initvals
     name     = streamname sid
     cty      = C.Array (transtype ty) (Just $ C.LitInt $ fromIntegral buffsize)
     buffsize = length xs
-    initvals = Just $ C.InitArray $ constarray ty xs
+    initvals = Just $ C.InitList $ constarray ty xs
 
 -- | Make a C index variable and initialise it to 0.
 mkindexdecln :: Id -> C.Decln
@@ -224,7 +225,7 @@ mkstructdecln :: Struct a => Type a -> C.Decln
 mkstructdecln (Struct x) = C.TypeDecln struct
   where
     struct = C.TypeSpec $ C.StructDecln (Just $ typename x) fields
-    fields = map mkfield (toValues x)
+    fields = NonEmpty.fromList $ map mkfield (toValues x)
 
     mkfield :: Value a -> C.FieldDecln
     mkfield (Value ty field) = C.FieldDecln (transtype ty) (fieldname field)


### PR DESCRIPTION
Adapt `copilot-c99` as required to work with new versions of the `language-c99*` libraries, as prescribed in the solution proposed for #371 .