### PR TITLE
`copilot-core`: Deprecate unused, `Array`-related classes, functions, instances. Refs #369.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,7 +1,8 @@
-2022-08-22
+2022-08-25
         * Deprecate Copilot.Core.PrettyDot. (#359)
         * Remove Copilot.Core.Type.Dynamic. (#360)
         * Split copilot-interpreter into separate library. (#361)
+        * Deprecate unused classes, functions from Array module. (#369)
 
 2022-07-07
         * Version bump (3.10). (#356)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -102,8 +102,6 @@ data Type :: * -> * where
   Double  :: Type Double
   Array   :: forall n t. ( KnownNat n
                          , Typed t
-                         , Typed (InnerType t)
-                         , Flatten t (InnerType t)
                          ) => Type t -> Type (Array n t)
   Struct  :: (Typed a, Struct a) => a -> Type a
 
@@ -209,7 +207,7 @@ instance Typed Float  where
 instance Typed Double where
   typeOf       = Double
   simpleType _ = SDouble
-instance (Typeable t, Typed t, KnownNat n, Flatten t (InnerType t), Typed (InnerType t)) => Typed (Array n t) where
+instance (Typeable t, Typed t, KnownNat n) => Typed (Array n t) where
   typeOf                = Array typeOf
   simpleType (Array t)  = SArray t
 

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -46,11 +46,14 @@ array xs | datalen == typelen = Array xs
              ") does not match length of type (" ++ show typelen ++ ")."
 
 -- | Association between an array and the type of the elements it contains.
+{-# DEPRECATED InnerType "This type family is deprecated in Copilot 3.11." #-}
 type family InnerType x where
   InnerType (Array _ x) = InnerType x
   InnerType x           = x
 
 -- | Flattening or conversion of arrays to lists.
+{-# DEPRECATED Flatten "This class is deprecated in Copilot 3.11." #-}
+{-# DEPRECATED flatten "This function is deprecated in Copilot 3.11." #-}
 class Flatten a b where
   -- | Flatten an array to a list.
   flatten :: Array n a -> [b]
@@ -63,10 +66,12 @@ instance Flatten a a where
 instance Flatten a b => Flatten (Array n a) b where
   flatten (Array xss) = concat $ map flatten xss
 
+-- | This instance is deprecated in Copilot 3.11.
 instance Foldable (Array n) where
   foldr f base (Array xs) = foldr f base xs
 
 -- | Total number of elements in a possibly nested array.
+{-# DEPRECATED size "This function is deprecated in Copilot 3.11." #-}
 size :: forall a n b. (Flatten a b, b ~ InnerType a) => Array n a -> Int
 size xs = length $ (flatten xs :: [b])
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,7 +1,8 @@
-2022-08-22
+2022-08-25
         * Deprecate prettyPrint. (#362)
         * Reimplement DynStableName without unsafeCoerce. (#262)
         * Use interpreter from copilot-interpreter. (#361)
+        * Remove unnecessary type constraints. (#369)
 
 2022-07-07
         * Version bump (3.10). (#356)

--- a/copilot-language/src/Copilot/Language/Operators/Array.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Array.hs
@@ -11,8 +11,7 @@ import Copilot.Core             ( Typed
                                 , Op2 (Index)
                                 , typeOf
                                 , Array
-                                , InnerType
-                                , Flatten)
+                                )
 import Copilot.Language.Stream  (Stream (..))
 
 import Data.Word                (Word32)
@@ -25,9 +24,6 @@ import GHC.TypeLits             (KnownNat)
 -- '5 Word8)@, then @s .!! 3@ has type @Stream Word8@ and contains the 3rd
 -- element (starting from zero) of the arrays in @s@ at any point in time.
 (.!!) :: ( KnownNat n
-         , t' ~ InnerType t
-         , Flatten t t'
          , Typed t
-         , Typed t'
          ) => Stream (Array n t) -> Stream Word32 -> Stream t
 arr .!! n = Op2 (Index typeOf) arr n


### PR DESCRIPTION
Deprecate classes, functions and instances from `Copilot.Core.Type.Array` that are not necessary, and adjust code across all of Copilot to remove mentions of classes from type constraints, as prescribed in the solution proposed for #369.