### PR TITLE
`copilot-c99`: Fix error handling buffers in generated code for `step`. Refs #314.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
-2022-08-23
+2022-08-29
         * Update to support language-c99-0.2.0. (#371)
+        * Fix error handling buffers in generated code for 'step'. (#314)
 
 2022-07-07
         * Version bump (3.10). (#356)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -51,7 +51,7 @@ library
 
                           , copilot-core        >= 3.10  && < 3.11
                           , language-c99        >= 0.2.0 && < 0.3
-                          , language-c99-simple >= 0.2.1 && < 0.3
+                          , language-c99-simple >= 0.2.2 && < 0.3
 
   exposed-modules         : Copilot.Compile.C99
 


### PR DESCRIPTION
Modify C99 code generator to use `sizeof` to calculate the actual amount of memory that must be copied in `memcpy` operations.