### PR TITLE
Release 3.11. Refs #376.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,4 +1,5 @@
-2022-08-29
+2022-09-07
+        * Version bump (3.11). (#376)
         * Update to support language-c99-0.2.0. (#371)
         * Fix error handling buffers in generated code for 'step'. (#314)
 

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-c99
-version                   : 3.10
+version                   : 3.11
 synopsis                  : A compiler for Copilot targeting C99.
 description               :
   This package is a back-end from Copilot to C.
@@ -49,7 +49,7 @@ library
                           , mtl                 >= 2.2 && < 2.4
                           , pretty              >= 1.1 && < 1.2
 
-                          , copilot-core        >= 3.10  && < 3.11
+                          , copilot-core        >= 3.11  && < 3.12
                           , language-c99        >= 0.2.0 && < 0.3
                           , language-c99-simple >= 0.2.2 && < 0.3
 

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,4 +1,5 @@
-2022-08-25
+2022-09-07
+        * Version bump (3.11). (#376)
         * Deprecate Copilot.Core.PrettyDot. (#359)
         * Remove Copilot.Core.Type.Dynamic. (#360)
         * Split copilot-interpreter into separate library. (#361)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-core
-version:             3.10
+version:             3.11
 synopsis:            An intermediate representation for Copilot.
 description:
   Intermediate representation for Copilot.

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,2 +1,3 @@
-2022-08-22
+2022-09-07
+        * Version bump (3.11). (#376)
         * Split copilot-interpreter into separate library. (#361)

--- a/copilot-interpreter/copilot-interpreter.cabal
+++ b/copilot-interpreter/copilot-interpreter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-interpreter
-version:             3.10
+version:             3.11
 synopsis:            Interpreter for Copilot.
 description:
   Interpreter for Copilot.

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,4 +1,5 @@
-2022-08-25
+2022-09-07
+        * Version bump (3.11). (#376)
         * Deprecate prettyPrint. (#362)
         * Reimplement DynStableName without unsafeCoerce. (#262)
         * Use interpreter from copilot-interpreter. (#361)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-language
-version:             3.10
+version:             3.11
 synopsis:            A Haskell-embedded DSL for monitoring hard real-time
                      distributed systems.
 description:
@@ -42,9 +42,9 @@ library
                , data-reify          >= 0.6 && < 0.7
                , mtl                 >= 2.0 && < 3
 
-               , copilot-core        >= 3.10 && < 3.11
-               , copilot-interpreter >= 3.10 && < 3.11
-               , copilot-theorem     >= 3.10 && < 3.11
+               , copilot-core        >= 3.11 && < 3.12
+               , copilot-interpreter >= 3.11 && < 3.12
+               , copilot-theorem     >= 3.11 && < 3.12
 
   exposed-modules: Copilot.Language
                  , Copilot.Language.Operators.BitWise

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2022-09-07
+        * Version bump (3.11). (#376)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Remove unnecessary dependencies from Cabal package. (#327)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-libraries
-version:             3.10
+version:             3.11
 synopsis:            Libraries for the Copilot language.
 description:
   Libraries for the Copilot language.
@@ -41,7 +41,7 @@ library
                , containers       >= 0.4 && < 0.7
                , mtl              >= 2.0 && < 2.4
                , parsec           >= 2.0 && < 3.2
-               , copilot-language >= 3.10 && < 3.11
+               , copilot-language >= 3.11 && < 3.12
 
   exposed-modules:
       Copilot.Library.Libraries

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2022-09-07
+        * Version bump (3.11). (#376)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Remove comment from cabal file. (#325)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -14,7 +14,7 @@ description:
   <https://copilot-language.github.io>.
 
 
-version                   : 3.10
+version                   : 3.11
 license                   : BSD3
 license-file              : LICENSE
 maintainer                : Ivan Perez <ivan.perezdominguez@nasa.gov>
@@ -63,7 +63,7 @@ library
                           , xml           >= 1.3 && < 1.4
                           , what4         >= 1.1 && < 1.4
 
-                          , copilot-core  >= 3.10 && < 3.11
+                          , copilot-core  >= 3.11 && < 3.12
 
   exposed-modules         : Copilot.Theorem
                           , Copilot.Theorem.Prove

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2022-09-07
+        * Version bump (3.11). (#376)
+
 2022-07-07
         * Version bump (3.10). (#356)
         * Run tests in CI. (#329)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -1,5 +1,5 @@
 name:                copilot
-version:             3.10
+version:             3.11
 cabal-version:       >= 1.10
 license:             BSD3
 license-file:        LICENSE
@@ -52,11 +52,11 @@ library
                      , directory            >= 1.3  && < 1.4
                      , filepath             >= 1.4  && < 1.5
 
-                     , copilot-core         >= 3.10 && < 3.11
-                     , copilot-theorem      >= 3.10 && < 3.11
-                     , copilot-language     >= 3.10 && < 3.11
-                     , copilot-libraries    >= 3.10 && < 3.11
-                     , copilot-c99          >= 3.10 && < 3.11
+                     , copilot-core         >= 3.11 && < 3.12
+                     , copilot-theorem      >= 3.11 && < 3.12
+                     , copilot-language     >= 3.11 && < 3.12
+                     , copilot-libraries    >= 3.11 && < 3.12
+                     , copilot-c99          >= 3.11 && < 3.12
 
 
     exposed-modules: Language.Copilot, Language.Copilot.Main


### PR DESCRIPTION
This PR updates the version numbers of all packages, as well as the version bounds of all dependencies on Copilot, as prescribed in the solution to #376.