### PR TITLE
Replaced Copilot.Core.Type.Equality definitions Refs #379

### DIFF
--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -39,7 +39,7 @@ module Copilot.Core.Type
 
 import Data.Int
 import Data.Word
-import Copilot.Core.Type.Equality
+import Data.Type.Equality ((:~:)(..), testEquality, TestEquality)
 import Copilot.Core.Type.Array
 
 import Data.Typeable (Typeable, typeRep)
@@ -114,19 +114,19 @@ tysize :: forall n t. KnownNat n => Type (Array n t) -> Int
 tysize ty@(Array ty'@(Array _)) = tylength ty * tysize ty'
 tysize ty@(Array _            ) = tylength ty
 
-instance EqualType Type where
-  (=~=) Bool   Bool   = Just Refl
-  (=~=) Int8   Int8   = Just Refl
-  (=~=) Int16  Int16  = Just Refl
-  (=~=) Int32  Int32  = Just Refl
-  (=~=) Int64  Int64  = Just Refl
-  (=~=) Word8  Word8  = Just Refl
-  (=~=) Word16 Word16 = Just Refl
-  (=~=) Word32 Word32 = Just Refl
-  (=~=) Word64 Word64 = Just Refl
-  (=~=) Float  Float  = Just Refl
-  (=~=) Double Double = Just Refl
-  (=~=) _ _ = Nothing
+instance TestEquality Type where
+  testEquality Bool   Bool   = Just Refl
+  testEquality Int8   Int8   = Just Refl
+  testEquality Int16  Int16  = Just Refl
+  testEquality Int32  Int32  = Just Refl
+  testEquality Int64  Int64  = Just Refl
+  testEquality Word8  Word8  = Just Refl
+  testEquality Word16 Word16 = Just Refl
+  testEquality Word32 Word32 = Just Refl
+  testEquality Word64 Word64 = Just Refl
+  testEquality Float  Float  = Just Refl
+  testEquality Double Double = Just Refl
+  testEquality _ _ = Nothing
 
 -- | A simple, monomorphic representation of types that facilitates putting
 -- variables in heterogeneous lists and environments in spite of their types
@@ -162,7 +162,7 @@ instance Eq SimpleType where
   SWord64 == SWord64  = True
   SFloat  == SFloat   = True
   SDouble == SDouble  = True
-  (SArray t1) == (SArray t2) | Just Refl <- t1 =~= t2 = True
+  (SArray t1) == (SArray t2) | Just Refl <- t1 `testEquality` t2 = True
                              | otherwise              = False
   SStruct == SStruct  = True
   _ == _ = False

--- a/copilot-core/src/Copilot/Core/Type/Equality.hs
+++ b/copilot-core/src/Copilot/Core/Type/Equality.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE Safe           #-}
 
 -- | Propositional equality and type equality.
-module Copilot.Core.Type.Equality
+module Copilot.Core.Type.Equality {-# DEPRECATED "Use Data.Type.Equality" #-}
   ( Equal (..)
   , EqualType (..)
   , coerce

--- a/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
+++ b/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
@@ -8,7 +8,7 @@ module Copilot.Theorem.TransSys.Type
   , U (..)
   ) where
 
-import Copilot.Core.Type.Equality
+import Data.Type.Equality ((:~:)(..), testEquality, TestEquality) 
 
 -- | A type at both value and type level.
 --
@@ -19,11 +19,11 @@ data Type a where
   Real    :: Type Double
 
 -- | Proofs of type equality.
-instance EqualType Type where
-  Bool    =~= Bool     = Just Refl
-  Integer =~= Integer  = Just Refl
-  Real    =~= Real     = Just Refl
-  _       =~= _        = Nothing
+instance TestEquality Type where
+  testEquality Bool  Bool  = Just Refl
+  testEquality Integer  Integer  = Just Refl
+  testEquality Real Real = Just Refl
+  testEquality _ _ = Nothing
 
 -- | Unknown types.
 --


### PR DESCRIPTION
This my attempt to address #379. 

The changes I made are:
- Deprecated module Copilot.Core.Type.Equality
- Replaced it's usage with the Data.Type.Equality. 
In particular:
      -  Replaced typeclass EqualType with typeclass TestEquality
      -  The function `(=~=)` with testEquality
       - the constructor Refl is the same but is now from Data.Type.Equality `(:~:)` constructor.
      
@ivanperez-keera please let me know if you need me to make any changes.
