### PR TITLE
copilot-c99: Remove deprecated flag from cabal file. Refs #380.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2022-10-18
+        * Removed deprecated flag from cabal file. (#380)
+
 2022-09-07
         * Version bump (3.11). (#376)
         * Update to support language-c99-0.2.0. (#371)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -38,11 +38,7 @@ library
   default-language        : Haskell2010
   hs-source-dirs          : src
 
-  -- The following -Wno-deprecations is temprary and related to issue
-  -- https://github.com/Copilot-Language/copilot/issues/237
-  -- It should be removed in a future version, when this library hides
-  -- internal modules.
-  ghc-options             : -Wall -Wno-deprecations
+  ghc-options             : -Wall
   build-depends           : base                >= 4.9 && < 5
                           , directory           >= 1.3 && < 1.4
                           , filepath            >= 1.4 && < 1.5


### PR DESCRIPTION
Remove the `--no-deprecation` flag from the cabal file as prescribed in the solution proposed in #380. 