### PR TITLE
`copilot-core`: move pretty-printer to separate library. Refs #383.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2022-10-21
+        * Deprecate Copilot.Core.PrettyPrinter. (#383)
+
 2022-09-07
         * Version bump (3.11). (#376)
         * Deprecate Copilot.Core.PrettyDot. (#359)

--- a/copilot-core/src/Copilot/Core/PrettyPrint.hs
+++ b/copilot-core/src/Copilot/Core/PrettyPrint.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE Safe  #-}
 
 module Copilot.Core.PrettyPrint
+  {-# DEPRECATED "This module is deprecated in Copilot 3.12. Use copilot-prettyprinter instead." #-}
   ( prettyPrint
   , ppExpr
   ) where

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,3 +1,6 @@
+2022-10-21
+        * Use pretty-printer from copilot-prettyprinter. (#383)
+
 2022-09-07
         * Version bump (3.11). (#376)
         * Split copilot-interpreter into separate library. (#361)

--- a/copilot-interpreter/copilot-interpreter.cabal
+++ b/copilot-interpreter/copilot-interpreter.cabal
@@ -76,6 +76,7 @@ test-suite unit-tests
 
     , copilot-core
     , copilot-interpreter
+    , copilot-prettyprinter
 
   hs-source-dirs:
     tests

--- a/copilot-interpreter/tests/Test/Copilot/Interpret/Eval.hs
+++ b/copilot-interpreter/tests/Test/Copilot/Interpret/Eval.hs
@@ -28,11 +28,11 @@ import Text.PrettyPrint.HughesPJ            (render)
 import Copilot.Core.Expr        (Expr (Const, Drop, Op1, Op2, Op3),
                                  UExpr (UExpr))
 import Copilot.Core.Operators   (Op1 (..), Op2 (..), Op3 (..))
-import Copilot.Core.PrettyPrint (ppExpr)
 import Copilot.Core.Spec        (Observer (..), Spec (..), Stream (Stream))
 import Copilot.Core.Type        (Type (..), Typed (typeOf))
 import Copilot.Interpret.Eval   (ExecTrace (interpObservers),
                                  ShowType (Haskell), eval)
+import Copilot.PrettyPrint      (ppExpr)
 
 -- Internal imports: auxiliary functions
 import Test.Extra (apply1, apply2, apply3)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2022-10-21
+        * Use pretty-printer from copilot-prettyprinter. (#383)
+
 2022-09-07
         * Version bump (3.11). (#376)
         * Deprecate prettyPrint. (#362)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -35,16 +35,17 @@ source-repository head
 library
   default-language: Haskell2010
   hs-source-dirs: src
-  build-depends: base                >= 4.9 && < 5
+  build-depends: base                  >= 4.9 && < 5
 
-               , array               >= 0.5 && < 0.6
-               , containers          >= 0.4 && < 0.7
-               , data-reify          >= 0.6 && < 0.7
-               , mtl                 >= 2.0 && < 3
+               , array                 >= 0.5 && < 0.6
+               , containers            >= 0.4 && < 0.7
+               , data-reify            >= 0.6 && < 0.7
+               , mtl                   >= 2.0 && < 3
 
-               , copilot-core        >= 3.11 && < 3.12
-               , copilot-interpreter >= 3.11 && < 3.12
-               , copilot-theorem     >= 3.11 && < 3.12
+               , copilot-core          >= 3.11 && < 3.12
+               , copilot-interpreter   >= 3.11 && < 3.12
+               , copilot-prettyprinter >= 3.11 && < 3.12
+               , copilot-theorem       >= 3.11 && < 3.12
 
   exposed-modules: Copilot.Language
                  , Copilot.Language.Operators.BitWise

--- a/copilot-language/src/Copilot/Language.hs
+++ b/copilot-language/src/Copilot/Language.hs
@@ -47,7 +47,6 @@ import Data.Word
 import Copilot.Core (Name, Typed)
 import Copilot.Core.Type
 import Copilot.Core.Type.Array
-import qualified Copilot.Core.PrettyPrint as PP
 import Copilot.Language.Error
 import Copilot.Language.Interpret
 import Copilot.Language.Operators.Boolean
@@ -68,6 +67,7 @@ import Copilot.Language.Reify
 import Copilot.Language.Prelude
 import Copilot.Language.Spec
 import Copilot.Language.Stream (Stream)
+import qualified Copilot.PrettyPrint as PP
 
 -- | Transform a high-level Copilot Language specification into a low-level
 -- Copilot Core specification and pretty-print it to stdout.

--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,0 +1,2 @@
+2022-10-21
+        * Create new library for pretty-printer. (#383)

--- a/copilot-prettyprinter/LICENSE
+++ b/copilot-prettyprinter/LICENSE
@@ -1,0 +1,29 @@
+2009
+BSD3 License terms
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of the developers nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/copilot-prettyprinter/README.md
+++ b/copilot-prettyprinter/README.md
@@ -1,0 +1,33 @@
+[![Build Status](https://travis-ci.com/Copilot-Language/copilot.svg?branch=master)](https://app.travis-ci.com/github/Copilot-Language/copilot)
+
+# Copilot: a stream DSL
+Copilot-prettyprinter implements a pretty-printer of Copilot Core
+specifications.
+
+Copilot is a runtime verification framework written in Haskell. It allows the
+user to write programs in a simple but powerful way using a stream-based
+approach.
+
+Programs can be interpreted for testing, or translated C99 code to be
+incorporated in a project, or as a standalone application. The C99 backend
+ensures us that the output is constant in memory and time, making it suitable
+for systems with hard realtime requirements.
+
+
+## Installation
+Copilot-prettyprinter can be found on
+[Hackage](https://hackage.haskell.org/package/copilot-prettyprinter). It is
+typically only installed as part of the complete Copilot distribution. For
+installation instructions, please refer to the [Copilot
+website](https://copilot-language.github.io).
+
+
+## Further information
+For further information, install instructions and documentation, please visit
+the Copilot website:
+[https://copilot-language.github.io](https://copilot-language.github.io)
+
+
+## License
+Copilot is distributed under the BSD-3-Clause license, which can be found
+[here](https://raw.githubusercontent.com/Copilot-Language/copilot/master/copilot-prettyprinter/LICENSE).

--- a/copilot-prettyprinter/Setup.hs
+++ b/copilot-prettyprinter/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/copilot-prettyprinter/copilot-prettyprinter.cabal
+++ b/copilot-prettyprinter/copilot-prettyprinter.cabal
@@ -1,0 +1,57 @@
+cabal-version:       >=1.10
+name:                copilot-prettyprinter
+version:             3.11
+synopsis:            A prettyprinter of Copilot Specifications.
+description:
+  A prettyprinter of Copilot specifications.
+  .
+  Copilot is a stream (i.e., infinite lists) domain-specific language (DSL) in
+  Haskell that compiles into embedded C.  Copilot contains an interpreter,
+  multiple back-end compilers, and other verification tools.
+  .
+  A tutorial, examples, and other information are available at
+  <https://copilot-language.github.io>.
+
+author:              Frank Dedden, Lee Pike, Robin Morisset, Alwyn Goodloe,
+                     Sebastian Niller, Nis Nordbyop Wegmann, Ivan Perez
+license:             BSD3
+license-file:        LICENSE
+maintainer:          Ivan Perez <ivan.perezdominguez@nasa.gov>
+homepage:            https://copilot-language.github.io
+bug-reports:         https://github.com/Copilot-Language/copilot/issues
+stability:           Experimental
+category:            Language, Embedded
+build-type:          Simple
+extra-source-files:  README.md, CHANGELOG
+
+x-curation: uncurated
+
+source-repository head
+    type:       git
+    location:   https://github.com/Copilot-Language/copilot.git
+    subdir:     copilot-prettyprinter
+
+library
+
+  default-language:  Haskell2010
+
+  hs-source-dirs:    src
+
+  ghc-options:
+    -Wall
+    -fno-warn-orphans
+
+  build-depends:
+    base   >= 4.9 && < 5,
+    pretty >= 1.0 && < 1.2,
+
+    copilot-core
+
+  exposed-modules:
+
+    Copilot.PrettyPrint
+
+  other-modules:
+
+    Copilot.PrettyPrint.Error
+    Copilot.PrettyPrint.Type

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
@@ -1,0 +1,194 @@
+-- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
+
+-- | A pretty printer for Copilot specifications.
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE Safe  #-}
+
+module Copilot.PrettyPrint
+  ( prettyPrint
+  , ppExpr
+  ) where
+
+import Copilot.Core
+import Copilot.PrettyPrint.Error (impossible)
+import Copilot.PrettyPrint.Type (showWithType, ShowType(..), showType)
+import Prelude hiding (id, (<>))
+import Text.PrettyPrint.HughesPJ
+import Data.List (intersperse)
+
+-- | Create a unique stream name by prefixing the given ID by a lowercase
+-- letter @"s"@.
+strmName :: Int -> Doc
+strmName id = text "s" <> int id
+
+-- | Pretty-print a Copilot expression.
+--
+-- The type is ignored, and only the expression is pretty-printed.
+ppExpr :: Expr a -> Doc
+ppExpr e0 = case e0 of
+  Const t x                  -> text (showWithType Haskell t x)
+  Drop _ 0 id                -> strmName id
+  Drop _ i id                -> text "drop" <+> text (show i) <+> strmName id
+  ExternVar _ name _         -> text "Ext_" <> (text name)
+  Local _ _ name e1 e2       -> text "local" <+> doubleQuotes (text name) <+> equals
+                                          <+> ppExpr e1 $$ text "in" <+> ppExpr e2
+  Var _ name                 -> text "var" <+> doubleQuotes (text name)
+  Op1 op e                   -> ppOp1 op (ppExpr e)
+  Op2 op e1 e2               -> ppOp2 op (ppExpr e1) (ppExpr e2)
+  Op3 op e1 e2 e3            -> ppOp3 op (ppExpr e1) (ppExpr e2) (ppExpr e3)
+  Label _ s e                -> text "label "<> doubleQuotes (text s) <+> (ppExpr e)
+
+-- | Pretty-print an untyped expression.
+--
+-- The type is ignored, and only the expression is pretty-printed.
+ppUExpr :: UExpr -> Doc
+ppUExpr UExpr { uExprExpr = e0 } = ppExpr e0
+
+-- | Pretty-print a unary operation.
+ppOp1 :: Op1 a b -> Doc -> Doc
+ppOp1 op = case op of
+  Not                     -> ppPrefix "not"
+  Abs _                   -> ppPrefix "abs"
+  Sign _                  -> ppPrefix "signum"
+  Recip _                 -> ppPrefix "recip"
+  Exp _                   -> ppPrefix "exp"
+  Sqrt _                  -> ppPrefix "sqrt"
+  Log _                   -> ppPrefix "log"
+  Sin _                   -> ppPrefix "sin"
+  Tan _                   -> ppPrefix "tan"
+  Cos _                   -> ppPrefix "cos"
+  Asin _                  -> ppPrefix "asin"
+  Atan _                  -> ppPrefix "atan"
+  Acos _                  -> ppPrefix "acos"
+  Sinh _                  -> ppPrefix "sinh"
+  Tanh _                  -> ppPrefix "tanh"
+  Cosh _                  -> ppPrefix "cosh"
+  Asinh _                 -> ppPrefix "asinh"
+  Atanh _                 -> ppPrefix "atanh"
+  Acosh _                 -> ppPrefix "acosh"
+  Ceiling _               -> ppPrefix "ceiling"
+  Floor _                 -> ppPrefix "floor"
+  BwNot _                 -> ppPrefix "~"
+  Cast _ _                -> ppPrefix "(cast)"
+  GetField (Struct _) _ f -> \e -> ppInfix "#" e (text $ accessorname f)
+  GetField _ _ _          -> impossible "ppOp1" "Copilot.PrettyPrint"
+
+-- | Pretty-print a binary operation.
+ppOp2 :: Op2 a b c -> Doc -> Doc -> Doc
+ppOp2 op = case op of
+  And          -> ppInfix "&&"
+  Or           -> ppInfix "||"
+  Add      _   -> ppInfix "+"
+  Sub      _   -> ppInfix "-"
+  Mul      _   -> ppInfix "*"
+  Div      _   -> ppInfix "div"
+  Mod      _   -> ppInfix "mod"
+  Fdiv     _   -> ppInfix "/"
+  Pow      _   -> ppInfix "**"
+  Logb     _   -> ppInfix "logBase"
+  Atan2    _   -> ppInfix "atan2"
+  Eq       _   -> ppInfix "=="
+  Ne       _   -> ppInfix "/="
+  Le       _   -> ppInfix "<="
+  Ge       _   -> ppInfix ">="
+  Lt       _   -> ppInfix "<"
+  Gt       _   -> ppInfix ">"
+  BwAnd    _   -> ppInfix "&"
+  BwOr     _   -> ppInfix "|"
+  BwXor    _   -> ppInfix "^"
+  BwShiftL _ _ -> ppInfix "<<"
+  BwShiftR _ _ -> ppInfix ">>"
+  Index    _   -> ppInfix ".!!"
+
+-- | Pretty-print a ternary operation.
+ppOp3 :: Op3 a b c d -> Doc -> Doc -> Doc -> Doc
+ppOp3 op = case op of
+  Mux _    -> \ doc1 doc2 doc3 ->
+    text "(if"   <+> doc1 <+>
+    text "then" <+> doc2 <+>
+    text "else" <+> doc3 <> text ")"
+
+-- | Parenthesize two 'Doc's, separated by an infix 'String'.
+ppInfix :: String -> Doc -> Doc -> Doc
+ppInfix cs doc1 doc2 = parens $ doc1 <+> text cs <+> doc2
+
+-- | Prefix a 'Doc' by a 'String'.
+ppPrefix :: String -> Doc -> Doc
+ppPrefix cs = (text cs <+>)
+
+-- | Pretty-print a Copilot stream as a case of a top-level function for
+-- streams of that type, by pattern matching on the stream name.
+ppStream :: Stream -> Doc
+ppStream
+  Stream
+    { streamId       = id
+    , streamBuffer   = buffer
+    , streamExpr     = e
+    , streamExprType = t
+    }
+      = (parens . text . showType) t
+          <+> strmName id
+    <+> text "="
+    <+> text ("["
+              ++ ( concat $ intersperse ","
+                              $ map (showWithType Haskell t) buffer )
+              ++ "]")
+    <+> text "++"
+    <+> ppExpr e
+
+-- | Pretty-print a Copilot trigger as a case of a top-level @trigger@
+-- function, by pattern matching on the trigger name.
+ppTrigger :: Trigger -> Doc
+ppTrigger
+  Trigger
+    { triggerName  = name
+    , triggerGuard = e
+    , triggerArgs  = args }
+  =   text "trigger" <+> text "\"" <> text name <> text "\""
+  <+> text "="
+  <+> ppExpr e
+  <+> lbrack
+  $$  (nest 2 $ vcat (punctuate comma $
+                          map (\a -> text "arg" <+> ppUExpr a) args))
+  $$  nest 2 rbrack
+
+-- | Pretty-print a Copilot observer as a case of a top-level @observer@
+-- function, by pattern matching on the observer name.
+ppObserver :: Observer -> Doc
+ppObserver
+  Observer
+    { observerName     = name
+    , observerExpr     = e }
+  =   text "observer \"" <> text name <> text "\""
+  <+> text "="
+  <+> ppExpr e
+
+-- | Pretty-print a Copilot property as a case of a top-level @property@
+-- function, by pattern matching on the property name.
+ppProperty :: Property -> Doc
+ppProperty
+  Property
+    { propertyName     = name
+    , propertyExpr     = e }
+  =   text "property \"" <> text name <> text "\""
+  <+> text "="
+  <+> ppExpr e
+
+-- | Pretty-print a Copilot specification, in the following order:
+--
+-- - Streams definitions
+-- - Trigger definitions
+-- - Observer definitions
+-- - Property definitions
+ppSpec :: Spec -> Doc
+ppSpec spec = cs $$ ds $$ es $$ fs
+  where
+    cs = foldr (($$) . ppStream)   empty (specStreams   spec)
+    ds = foldr (($$) . ppTrigger)  empty (specTriggers  spec)
+    es = foldr (($$) . ppObserver) empty (specObservers spec)
+    fs = foldr (($$) . ppProperty) empty (specProperties spec)
+
+-- | Pretty-print a Copilot specification.
+prettyPrint :: Spec -> String
+prettyPrint = render . ppSpec

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint/Error.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint/Error.hs
@@ -1,0 +1,24 @@
+-- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
+
+{-# LANGUAGE Safe #-}
+
+-- | Custom functions to report error messages to users.
+module Copilot.PrettyPrint.Error
+  ( impossible
+  , badUsage ) where
+
+-- | Report an error due to a bug in Copilot.
+impossible :: String -- ^ Name of the function in which the error was detected.
+           -> String -- ^ Name of the package in which the function is located.
+           -> a
+impossible function package =
+  error $ "\"Impossible\" error in function "
+    ++ function ++ ", in package " ++ package
+    ++ ". Please file an issue at "
+    ++ "https://github.com/Copilot-Language/copilot/issues"
+    ++ "or email the maintainers at <ivan.perezdominguez@nasa.gov>"
+
+-- | Report an error due to an error detected by Copilot (e.g., user error).
+badUsage :: String -- ^ Description of the error.
+         -> a
+badUsage msg = error $ "Copilot error: " ++ msg

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint/Type.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint/Type.hs
@@ -1,0 +1,77 @@
+-- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
+
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE Safe                      #-}
+
+-- | Show Copilot Core types and typed values.
+module Copilot.PrettyPrint.Type
+  ( showWithType
+  , ShowType(..)
+  , showType
+  ) where
+
+import Copilot.Core.Type
+
+-- Are we proving equivalence with a C backend, in which case we want to show
+-- Booleans as '0' and '1'.
+
+-- | Target language for showing a typed value. Used to adapt the
+-- representation of booleans.
+data ShowType = C | Haskell
+
+-- | Show a value. The representation depends on the type and the target
+-- language. Booleans are represented differently depending on the backend.
+showWithType :: ShowType -> Type a -> a -> String
+showWithType showT t x =
+  case showT of
+    C         -> case t of
+                   Bool -> if x then "1" else "0"
+                   _    -> sw
+    Haskell   -> case t of
+                   Bool -> if x then "true" else "false"
+                   _    -> sw
+  where
+  sw = case showWit t of
+         ShowWit -> show x
+
+-- | Show Copilot Core type.
+showType :: Type a -> String
+showType t =
+  case t of
+    Bool   -> "Bool"
+    Int8   -> "Int8"
+    Int16  -> "Int16"
+    Int32  -> "Int32"
+    Int64  -> "Int64"
+    Word8  -> "Word8"
+    Word16 -> "Word16"
+    Word32 -> "Word32"
+    Word64 -> "Word64"
+    Float  -> "Float"
+    Double -> "Double"
+    Array t -> "Array " ++ showType t
+    Struct t -> "Struct"
+
+-- * Auxiliary show instance
+
+-- | Witness datatype for showing a value, used by 'showWithType'.
+data ShowWit a = Show a => ShowWit
+
+-- | Turn a type into a show witness.
+showWit :: Type a -> ShowWit a
+showWit t =
+  case t of
+    Bool   -> ShowWit
+    Int8   -> ShowWit
+    Int16  -> ShowWit
+    Int32  -> ShowWit
+    Int64  -> ShowWit
+    Word8  -> ShowWit
+    Word16 -> ShowWit
+    Word32 -> ShowWit
+    Word64 -> ShowWit
+    Float  -> ShowWit
+    Double -> ShowWit
+    Array t -> ShowWit
+    Struct t -> ShowWit

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,6 @@
-2022-10-11
+2022-10-21
         * Add functionality for bisimulation proofs of Copilot specifications. (#363)
+        * Use pretty-printer from copilot-prettyprinter. (#383)
 
 2022-09-07
         * Version bump (3.11). (#376)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -45,25 +45,26 @@ library
                             -fno-warn-missing-signatures
                             -fcontext-stack=100
 
-  build-depends           : base          >= 4.9 && < 5
-                          , bimap         (>= 0.3 && < 0.4) || (>= 0.5 && < 0.6)
-                          , bv-sized      >= 1.0.2 && < 1.1
-                          , containers    >= 0.4 && < 0.7
-                          , data-default  >= 0.7 && < 0.8
-                          , directory     >= 1.3 && < 1.4
-                          , libBF         >= 0.6.2 && < 0.7
-                          , mtl           >= 2.0 && < 2.4
-                          , panic         >= 0.4.0 && < 0.5
-                          , parsec        >= 2.0 && < 3.2
-                          , parameterized-utils >= 2.1.1 && < 2.2
-                          , pretty        >= 1.0 && < 1.2
-                          , process       >= 1.6 && < 1.7
-                          , random        >= 1.1 && < 1.3
-                          , transformers  >= 0.5 && < 0.7
-                          , xml           >= 1.3 && < 1.4
-                          , what4         >= 1.3 && < 1.4
+  build-depends           : base                  >= 4.9 && < 5
+                          , bimap                 (>= 0.3 && < 0.4) || (>= 0.5 && < 0.6)
+                          , bv-sized              >= 1.0.2 && < 1.1
+                          , containers            >= 0.4 && < 0.7
+                          , data-default          >= 0.7 && < 0.8
+                          , directory             >= 1.3 && < 1.4
+                          , libBF                 >= 0.6.2 && < 0.7
+                          , mtl                   >= 2.0 && < 2.4
+                          , panic                 >= 0.4.0 && < 0.5
+                          , parsec                >= 2.0 && < 3.2
+                          , parameterized-utils   >= 2.1.1 && < 2.2
+                          , pretty                >= 1.0 && < 1.2
+                          , process               >= 1.6 && < 1.7
+                          , random                >= 1.1 && < 1.3
+                          , transformers          >= 0.5 && < 0.7
+                          , xml                   >= 1.3 && < 1.4
+                          , what4                 >= 1.3 && < 1.4
 
-                          , copilot-core  >= 3.11 && < 3.12
+                          , copilot-core          >= 3.11 && < 3.12
+                          , copilot-prettyprinter >= 3.11 && < 3.12
 
   exposed-modules         : Copilot.Theorem
                           , Copilot.Theorem.Prove

--- a/copilot-theorem/src/Copilot/Theorem/What4/Translate.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4/Translate.hs
@@ -71,10 +71,10 @@ import qualified What4.SpecialFunctions         as WSF
 
 import qualified Copilot.Core.Expr              as CE
 import qualified Copilot.Core.Operators         as CE
-import qualified Copilot.Core.PrettyPrint       as CP
 import qualified Copilot.Core.Spec              as CS
 import qualified Copilot.Core.Type              as CT
 import qualified Copilot.Core.Type.Array        as CT
+import qualified Copilot.PrettyPrint            as CP
 
 -- Translation into What4
 


### PR DESCRIPTION
Create separate library for the pretty-printer, as prescribed in the solution proposed for #383.