### PR TITLE
`copilot-c99`: Generate type declarations in separate header file. Refs #373.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
-2022-10-18
+2022-10-31
         * Removed deprecated flag from cabal file. (#380)
+        * Generate type declarations in separate header file. (#373)
 
 2022-09-07
         * Version bump (3.11). (#376)

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -160,3 +160,24 @@ compileh cSettings spec = C.TransUnit declns []
     stepdecln :: C.Decln
     stepdecln = C.FunDecln Nothing (C.TypeSpec C.Void)
                     (cSettingsStepFunctionName cSettings) []
+
+-- | Generate a C translation unit that contains all type declarations needed
+-- by the Copilot specification.
+compileTypeDeclns :: CSettings -> Spec -> C.TransUnit
+compileTypeDeclns _cSettings spec = C.TransUnit declns []
+  where
+    declns = mkTypeDeclns exprs
+
+    exprs    = gatherexprs streams triggers
+    streams  = specStreams spec
+    triggers = specTriggers spec
+
+    -- Generate type declarations.
+    mkTypeDeclns :: [UExpr] -> [C.Decln]
+    mkTypeDeclns es = catMaybes $ map mkTypeDecln uTypes
+      where
+        uTypes = nub $ concatMap (\(UExpr _ e) -> exprtypes e) es
+
+        mkTypeDecln (UType ty) = case ty of
+          Struct _ -> Just $ mkstructdecln ty
+          _        -> Nothing

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -74,20 +74,9 @@ compilec cSettings spec = C.TransUnit declns funs
     streams  = specStreams spec
     triggers = specTriggers spec
     exts     = gatherexts streams triggers
-    exprs    = gatherexprs streams triggers
 
-    declns = mkstructdeclns exprs ++ mkexts exts ++ mkglobals streams
+    declns = mkexts exts ++ mkglobals streams
     funs   = genfuns streams triggers ++ [mkstep cSettings streams triggers exts]
-
-    -- Write struct datatypes
-    mkstructdeclns :: [UExpr] -> [C.Decln]
-    mkstructdeclns es = catMaybes $ map mkdecln utypes
-      where
-        mkdecln (UType ty) = case ty of
-          Struct x -> Just $ mkstructdecln ty
-          _        -> Nothing
-
-        utypes = nub $ concatMap (\(UExpr _ e) -> exprtypes e) es
 
     -- Make declarations for copies of external variables.
     mkexts :: [External] -> [C.Decln]

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -46,6 +46,7 @@ compileWith cSettings prefix spec
                              , "#include <stdlib.h>"
                              , "#include <math.h>"
                              , ""
+                             , "#include \"" ++ prefix ++ "_types.h\""
                              , "#include \"" ++ prefix ++ ".h\""
                              , ""
                              ]


### PR DESCRIPTION
Modify C99 backend to write type declarations in a separate header file. Include this file _prior_ to declaring handlers in the generated `.c` file, as prescribed in the solution proposed for #373.