### PR TITLE
Replace `Copilot.Core.Type.Equality` with `base:Data.Type.Equality`. Refs #379.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,5 +1,7 @@
-2022-10-21
+2022-11-02
         * Deprecate Copilot.Core.PrettyPrinter. (#383)
+        * Replace uses of Copilot.Core.Type.Equality with definitions from
+          base:Data.Type.Equality; deprecate Copilot.Core.Type.Equality. (#379)
 
 2022-09-07
         * Version bump (3.11). (#376)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -39,7 +39,8 @@ module Copilot.Core.Type
 
 import Data.Int
 import Data.Word
-import Copilot.Core.Type.Equality
+import Data.Type.Equality         as DE
+import Copilot.Core.Type.Equality as CE
 import Copilot.Core.Type.Array
 
 import Data.Typeable (Typeable, typeRep)
@@ -115,18 +116,32 @@ tysize ty@(Array ty'@(Array _)) = tylength ty * tysize ty'
 tysize ty@(Array _            ) = tylength ty
 
 instance EqualType Type where
-  (=~=) Bool   Bool   = Just Refl
-  (=~=) Int8   Int8   = Just Refl
-  (=~=) Int16  Int16  = Just Refl
-  (=~=) Int32  Int32  = Just Refl
-  (=~=) Int64  Int64  = Just Refl
-  (=~=) Word8  Word8  = Just Refl
-  (=~=) Word16 Word16 = Just Refl
-  (=~=) Word32 Word32 = Just Refl
-  (=~=) Word64 Word64 = Just Refl
-  (=~=) Float  Float  = Just Refl
-  (=~=) Double Double = Just Refl
+  (=~=) Bool   Bool   = Just CE.Refl
+  (=~=) Int8   Int8   = Just CE.Refl
+  (=~=) Int16  Int16  = Just CE.Refl
+  (=~=) Int32  Int32  = Just CE.Refl
+  (=~=) Int64  Int64  = Just CE.Refl
+  (=~=) Word8  Word8  = Just CE.Refl
+  (=~=) Word16 Word16 = Just CE.Refl
+  (=~=) Word32 Word32 = Just CE.Refl
+  (=~=) Word64 Word64 = Just CE.Refl
+  (=~=) Float  Float  = Just CE.Refl
+  (=~=) Double Double = Just CE.Refl
   (=~=) _ _ = Nothing
+
+instance TestEquality Type where
+  testEquality Bool   Bool   = Just DE.Refl
+  testEquality Int8   Int8   = Just DE.Refl
+  testEquality Int16  Int16  = Just DE.Refl
+  testEquality Int32  Int32  = Just DE.Refl
+  testEquality Int64  Int64  = Just DE.Refl
+  testEquality Word8  Word8  = Just DE.Refl
+  testEquality Word16 Word16 = Just DE.Refl
+  testEquality Word32 Word32 = Just DE.Refl
+  testEquality Word64 Word64 = Just DE.Refl
+  testEquality Float  Float  = Just DE.Refl
+  testEquality Double Double = Just DE.Refl
+  testEquality _ _ = Nothing
 
 -- | A simple, monomorphic representation of types that facilitates putting
 -- variables in heterogeneous lists and environments in spite of their types
@@ -162,8 +177,8 @@ instance Eq SimpleType where
   SWord64 == SWord64  = True
   SFloat  == SFloat   = True
   SDouble == SDouble  = True
-  (SArray t1) == (SArray t2) | Just Refl <- t1 =~= t2 = True
-                             | otherwise              = False
+  (SArray t1) == (SArray t2) | Just DE.Refl <- testEquality t1 t2 = True
+                             | otherwise                          = False
   SStruct == SStruct  = True
   _ == _ = False
 

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -1,3 +1,7 @@
+-- The following flag is disabled in this module so that the import of
+-- Copilot.Core.Type.Equality does not give rise to warnings.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
 
 -- | Typing for Core.

--- a/copilot-core/src/Copilot/Core/Type/Equality.hs
+++ b/copilot-core/src/Copilot/Core/Type/Equality.hs
@@ -6,6 +6,7 @@
 
 -- | Propositional equality and type equality.
 module Copilot.Core.Type.Equality
+  {-# DEPRECATED "This module is deprecated in Copilot 3.12. Use base:Data.Type.Equality instead." #-}
   ( Equal (..)
   , EqualType (..)
   , coerce

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,6 +1,8 @@
-2022-10-21
+2022-11-02
         * Add functionality for bisimulation proofs of Copilot specifications. (#363)
         * Use pretty-printer from copilot-prettyprinter. (#383)
+        * Replace uses of Copilot.Core.Type.Equality with definitions from
+          base:Data.Type.Equality. (#379)
 
 2022-09-07
         * Version bump (3.11). (#376)

--- a/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
+++ b/copilot-theorem/src/Copilot/Theorem/TransSys/Type.hs
@@ -8,7 +8,7 @@ module Copilot.Theorem.TransSys.Type
   , U (..)
   ) where
 
-import Copilot.Core.Type.Equality
+import Data.Type.Equality
 
 -- | A type at both value and type level.
 --
@@ -19,11 +19,11 @@ data Type a where
   Real    :: Type Double
 
 -- | Proofs of type equality.
-instance EqualType Type where
-  Bool    =~= Bool     = Just Refl
-  Integer =~= Integer  = Just Refl
-  Real    =~= Real     = Just Refl
-  _       =~= _        = Nothing
+instance TestEquality Type where
+  testEquality Bool    Bool     = Just Refl
+  testEquality Integer Integer  = Just Refl
+  testEquality Real    Real     = Just Refl
+  testEquality _       _        = Nothing
 
 -- | Unknown types.
 --


### PR DESCRIPTION
Replace all uses of `copilot-core:Copilot.Core.Type.Equality` with entities from `base:Data.Type.Equality`, and deprecate the module `copilot-core:Copilot.Core.Type.Equality`, as prescribed in the solution proposed for #379.