### PR TITLE
`copilot-core`: Conform to style guide. Refs #332.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,7 +1,8 @@
-2022-11-02
+2022-11-03
         * Deprecate Copilot.Core.PrettyPrinter. (#383)
         * Replace uses of Copilot.Core.Type.Equality with definitions from
           base:Data.Type.Equality; deprecate Copilot.Core.Type.Equality. (#379)
+        * Compliance with style guide. (#332)
 
 2022-09-07
         * Version bump (3.11). (#376)

--- a/copilot-core/src/Copilot/Core.hs
+++ b/copilot-core/src/Copilot/Core.hs
@@ -25,15 +25,16 @@
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Copilot.Core
-  ( module Copilot.Core.Expr
-  , module Copilot.Core.External
-  , module Copilot.Core.Operators
-  , module Copilot.Core.Spec
-  , module Copilot.Core.Type
-  , module Copilot.Core.Type.Array
-  , module Data.Int
-  , module Data.Word
-  ) where
+    ( module Copilot.Core.Expr
+    , module Copilot.Core.External
+    , module Copilot.Core.Operators
+    , module Copilot.Core.Spec
+    , module Copilot.Core.Type
+    , module Copilot.Core.Type.Array
+    , module Data.Int
+    , module Data.Word
+    )
+  where
 
 -- External imports
 import Data.Int

--- a/copilot-core/src/Copilot/Core.hs
+++ b/copilot-core/src/Copilot/Core.hs
@@ -35,11 +35,14 @@ module Copilot.Core
   , module Data.Word
   ) where
 
+-- External imports
+import Data.Int
+import Data.Word
+
+-- Internal imports
 import Copilot.Core.Expr
 import Copilot.Core.External -- See GHC flag enabled above
 import Copilot.Core.Operators
 import Copilot.Core.Spec
 import Copilot.Core.Type
 import Copilot.Core.Type.Array
-import Data.Int
-import Data.Word

--- a/copilot-core/src/Copilot/Core.hs
+++ b/copilot-core/src/Copilot/Core.hs
@@ -1,6 +1,7 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
--- | Intermediate representation for Copilot specifications.
+-- |
+-- Description: Intermediate representation for Copilot specifications.
+-- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
 -- The following articles might also be useful:
 --
 -- * Carette, Jacques and Kiselyov, Oleg and Shan, Chung-chieh,

--- a/copilot-core/src/Copilot/Core.hs
+++ b/copilot-core/src/Copilot/Core.hs
@@ -1,3 +1,10 @@
+{-# LANGUAGE Safe #-}
+
+-- The following warning is enabled in this module so that the import of
+-- Copilot.Core.External does not give rise to a warning. It can be removed
+-- when that module is removed from the implementation.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- |
 -- Description: Intermediate representation for Copilot specifications.
 -- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
@@ -18,13 +25,6 @@
 -- ("Copilot.Core.Interpret")
 -- and the pretty-printer
 -- ("Copilot.Core.PrettyPrint").
-
-{-# LANGUAGE Safe #-}
--- The following warning is enabled in this module so that the import of
--- Copilot.Core.External does not give rise to a warning. It can be removed
--- when that module is removed from the implementation.
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-
 module Copilot.Core
     ( module Copilot.Core.Expr
     , module Copilot.Core.External

--- a/copilot-core/src/Copilot/Core/Error.hs
+++ b/copilot-core/src/Copilot/Core/Error.hs
@@ -1,8 +1,8 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE Safe #-}
 
--- | Custom functions to report error messages to users.
+-- |
+-- Description: Custom functions to report error messages to users.
+-- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
 module Copilot.Core.Error
     ( impossible
     , badUsage )

--- a/copilot-core/src/Copilot/Core/Error.hs
+++ b/copilot-core/src/Copilot/Core/Error.hs
@@ -4,8 +4,9 @@
 
 -- | Custom functions to report error messages to users.
 module Copilot.Core.Error
-  ( impossible
-  , badUsage ) where
+    ( impossible
+    , badUsage )
+  where
 
 -- | Report an error due to a bug in Copilot.
 impossible :: String -- ^ Name of the function in which the error was detected.

--- a/copilot-core/src/Copilot/Core/Error.hs
+++ b/copilot-core/src/Copilot/Core/Error.hs
@@ -5,7 +5,8 @@
 -- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
 module Copilot.Core.Error
     ( impossible
-    , badUsage )
+    , badUsage
+    )
   where
 
 -- | Report an error due to a bug in Copilot.

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -37,15 +37,32 @@ type DropIdx = Word32
 -- representation contains information about the types of elements in the
 -- stream.
 data Expr a where
-  Const     :: Typeable a => Type a -> a -> Expr a
-  Drop      :: Typeable a => Type a -> DropIdx -> Id -> Expr a
-  Local     :: Typeable a => Type a -> Type b -> Name -> Expr a -> Expr b -> Expr b
-  Var       :: Typeable a => Type a -> Name -> Expr a
-  ExternVar :: Typeable a => Type a -> Name -> Maybe [a] -> Expr a
-  Op1       :: Typeable a => Op1 a b -> Expr a -> Expr b
-  Op2       :: (Typeable a, Typeable b) => Op2 a b c -> Expr a -> Expr b -> Expr c
-  Op3       :: (Typeable a, Typeable b, Typeable c) => Op3 a b c d -> Expr a -> Expr b -> Expr c -> Expr d
-  Label     :: Typeable a => Type a -> String -> Expr a -> Expr a
+  Const     :: Typeable a
+            => Type a -> a -> Expr a
+
+  Drop      :: Typeable a
+            => Type a -> DropIdx -> Id -> Expr a
+
+  Local     :: Typeable a
+            => Type a -> Type b -> Name -> Expr a -> Expr b -> Expr b
+
+  Var       :: Typeable a
+            => Type a -> Name -> Expr a
+
+  ExternVar :: Typeable a
+            => Type a -> Name -> Maybe [a] -> Expr a
+
+  Op1       :: Typeable a
+            => Op1 a b -> Expr a -> Expr b
+
+  Op2       :: (Typeable a, Typeable b)
+            => Op2 a b c -> Expr a -> Expr b -> Expr c
+
+  Op3       :: (Typeable a, Typeable b, Typeable c)
+            => Op3 a b c d -> Expr a -> Expr b -> Expr c -> Expr d
+
+  Label     :: Typeable a
+            => Type a -> String -> Expr a -> Expr a
 
 -- | A untyped expression that carries the information about the type of the
 -- expression as a value, as opposed to exposing it at type level (using an

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -13,11 +13,13 @@ module Copilot.Core.Expr
   , DropIdx
   ) where
 
-import Copilot.Core.Operators (Op1, Op2, Op3)
-import Copilot.Core.Type (Type)
-import Data.Word (Word32)
-
+-- External imports
 import Data.Typeable (Typeable)
+import Data.Word     (Word32)
+
+-- Internal imports
+import Copilot.Core.Operators (Op1, Op2, Op3)
+import Copilot.Core.Type      (Type)
 
 -- | A stream identifier.
 type Id = Int

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -37,19 +37,19 @@ type DropIdx = Word32
 -- representation contains information about the types of elements in the
 -- stream.
 data Expr a where
-  Const        :: Typeable a => Type a -> a -> Expr a
-  Drop         :: Typeable a => Type a -> DropIdx -> Id -> Expr a
-  Local        :: Typeable a => Type a -> Type b -> Name -> Expr a -> Expr b -> Expr b
-  Var          :: Typeable a => Type a -> Name -> Expr a
-  ExternVar    :: Typeable a => Type a -> Name -> Maybe [a] -> Expr a
-  Op1          :: Typeable a => Op1 a b -> Expr a -> Expr b
-  Op2          :: (Typeable a, Typeable b) => Op2 a b c -> Expr a -> Expr b -> Expr c
-  Op3          :: (Typeable a, Typeable b, Typeable c) => Op3 a b c d -> Expr a -> Expr b -> Expr c -> Expr d
-  Label        :: Typeable a => Type a -> String -> Expr a -> Expr a
+  Const     :: Typeable a => Type a -> a -> Expr a
+  Drop      :: Typeable a => Type a -> DropIdx -> Id -> Expr a
+  Local     :: Typeable a => Type a -> Type b -> Name -> Expr a -> Expr b -> Expr b
+  Var       :: Typeable a => Type a -> Name -> Expr a
+  ExternVar :: Typeable a => Type a -> Name -> Maybe [a] -> Expr a
+  Op1       :: Typeable a => Op1 a b -> Expr a -> Expr b
+  Op2       :: (Typeable a, Typeable b) => Op2 a b c -> Expr a -> Expr b -> Expr c
+  Op3       :: (Typeable a, Typeable b, Typeable c) => Op3 a b c d -> Expr a -> Expr b -> Expr c -> Expr d
+  Label     :: Typeable a => Type a -> String -> Expr a -> Expr a
 
 -- | A untyped expression that carries the information about the type of the
 -- expression as a value, as opposed to exposing it at type level (using an
 -- existential).
-data UExpr = forall a. Typeable a => UExpr
+data UExpr = forall a . Typeable a => UExpr
   { uExprType :: Type a
   , uExprExpr :: Expr a }

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -6,12 +6,13 @@
 
 -- | Internal representation of Copilot stream expressions.
 module Copilot.Core.Expr
-  ( Id
-  , Name
-  , Expr (..)
-  , UExpr (..)
-  , DropIdx
-  ) where
+    ( Id
+    , Name
+    , Expr (..)
+    , UExpr (..)
+    , DropIdx
+    )
+  where
 
 -- External imports
 import Data.Typeable (Typeable)

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -1,10 +1,10 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE Safe                      #-}
 
--- | Internal representation of Copilot stream expressions.
+-- |
+-- Description: Internal representation of Copilot stream expressions.
+-- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
 module Copilot.Core.Expr
     ( Id
     , Name

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -52,4 +52,5 @@ data Expr a where
 -- existential).
 data UExpr = forall a . Typeable a => UExpr
   { uExprType :: Type a
-  , uExprExpr :: Expr a }
+  , uExprExpr :: Expr a
+  }

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -1,10 +1,10 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE GADTs      #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE Safe       #-}
 
--- | Internal representation of Copilot operators.
+-- |
+-- Description: Internal representation of Copilot operators.
+-- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
 module Copilot.Core.Operators
     ( Op1 (..)
     , Op2 (..)

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -11,12 +11,14 @@ module Copilot.Core.Operators
   , Op3 (..)
   ) where
 
-import GHC.TypeLits             (KnownSymbol)
+-- External imports
+import Data.Bits    (Bits)
+import Data.Word    (Word32)
+import GHC.TypeLits (KnownSymbol)
 
-import Copilot.Core.Type        (Type(..), Field(..))
-import Copilot.Core.Type.Array  (Array)
-import Data.Bits                (Bits)
-import Data.Word                (Word32)
+-- Internal imports
+import Copilot.Core.Type       (Field (..), Type (..))
+import Copilot.Core.Type.Array (Array)
 
 -- | Unary operators.
 data Op1 a b where

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -50,7 +50,7 @@ data Op1 a b where
   Ceiling  :: RealFrac a => Type a -> Op1 a a
   Floor    :: RealFrac a => Type a -> Op1 a a
   -- Bitwise operators.
-  BwNot    :: Bits     a => Type a -> Op1 a a
+  BwNot    :: Bits a => Type a -> Op1 a a
   -- Casting operator.
   Cast     :: (Integral a, Num b) => Type a -> Type b -> Op1 a b
               -- ^ Casting operator.
@@ -90,8 +90,8 @@ data Op2 a b c where
   BwAnd    :: Bits a => Type a -> Op2 a a a
   BwOr     :: Bits a => Type a -> Op2 a a a
   BwXor    :: Bits a => Type a -> Op2 a a a
-  BwShiftL :: ( Bits a, Integral b ) => Type a -> Type b -> Op2 a b a
-  BwShiftR :: ( Bits a, Integral b ) => Type a -> Type b -> Op2 a b a
+  BwShiftL :: (Bits a, Integral b) => Type a -> Type b -> Op2 a b a
+  BwShiftR :: (Bits a, Integral b) => Type a -> Type b -> Op2 a b a
   -- Array operator.
 
   Index    :: Type (Array n t) -> Op2 (Array n t) Word32 t
@@ -100,4 +100,4 @@ data Op2 a b c where
 -- | Ternary operators.
 data Op3 a b c d where
   -- Conditional operator:
-  Mux   :: Type a -> Op3 Bool a a a
+  Mux :: Type a -> Op3 Bool a a a

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -15,7 +15,7 @@ import GHC.TypeLits             (KnownSymbol)
 
 import Copilot.Core.Type        (Type(..), Field(..))
 import Copilot.Core.Type.Array  (Array)
-import Data.Bits
+import Data.Bits                (Bits)
 import Data.Word                (Word32)
 
 -- | Unary operators.

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -6,10 +6,11 @@
 
 -- | Internal representation of Copilot operators.
 module Copilot.Core.Operators
-  ( Op1 (..)
-  , Op2 (..)
-  , Op3 (..)
-  ) where
+    ( Op1 (..)
+    , Op2 (..)
+    , Op3 (..)
+    )
+  where
 
 -- External imports
 import Data.Bits    (Bits)

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -93,7 +93,6 @@ data Op2 a b c where
   BwShiftL :: (Bits a, Integral b) => Type a -> Type b -> Op2 a b a
   BwShiftR :: (Bits a, Integral b) => Type a -> Type b -> Op2 a b a
   -- Array operator.
-
   Index    :: Type (Array n t) -> Op2 (Array n t) Word32 t
               -- ^ Array access/projection of an array element.
 

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -98,5 +98,5 @@ data Op2 a b c where
 
 -- | Ternary operators.
 data Op3 a b c d where
-  -- Conditional operator:
+  -- Conditional operator.
   Mux :: Type a -> Op3 Bool a a a

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -21,9 +21,12 @@ module Copilot.Core.Spec
   , Property (..)
   ) where
 
-import Copilot.Core.Expr (Name, Id, Expr, UExpr)
-import Copilot.Core.Type (Type, Typed)
+-- External imports
 import Data.Typeable (Typeable)
+
+-- Internal imports
+import Copilot.Core.Expr (Expr, Id, Name, UExpr)
+import Copilot.Core.Type (Type, Typed)
 
 -- | A stream in an infinite succession of values of the same type.
 --

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -1,10 +1,11 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE Safe                      #-}
 
--- | Copilot specifications constitute the main declaration of Copilot modules.
+-- |
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Copilot specifications constitute the main declaration of Copilot modules.
 --
 -- A specification normally contains the association between streams to monitor
 -- and their handling functions, or streams to observe, or a theorem that must

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -35,15 +35,15 @@ import Copilot.Core.Type (Type, Typed)
 -- Stream can carry different types of data. Boolean streams play a special
 -- role: they are used by other parts (e.g., 'Trigger') to detect when the
 -- properties being monitored are violated.
-data Stream = forall a. (Typeable a, Typed a) => Stream
-  { streamId         :: Id
-  , streamBuffer     :: [a]
-  , streamExpr       :: Expr a
-  , streamExprType   :: Type a }
+data Stream = forall a . (Typeable a, Typed a) => Stream
+  { streamId       :: Id
+  , streamBuffer   :: [a]
+  , streamExpr     :: Expr a
+  , streamExprType :: Type a }
 
 -- | An observer, representing a stream that we observe during interpretation
 -- at every sample.
-data Observer = forall a. Typeable a => Observer
+data Observer = forall a . Typeable a => Observer
   { observerName     :: Name
   , observerExpr     :: Expr a
   , observerExprType :: Type a }
@@ -51,20 +51,20 @@ data Observer = forall a. Typeable a => Observer
 -- | A trigger, representing a function we execute when a boolean stream becomes
 -- true at a sample.
 data Trigger = Trigger
-  { triggerName      :: Name
-  , triggerGuard     :: Expr Bool
-  , triggerArgs      :: [UExpr] }
+  { triggerName  :: Name
+  , triggerGuard :: Expr Bool
+  , triggerArgs  :: [UExpr] }
 
 -- | A property, representing a boolean stream that is existentially or
 -- universally quantified over time.
 data Property = Property
-  { propertyName     :: Name
-  , propertyExpr     :: Expr Bool }
+  { propertyName :: Name
+  , propertyExpr :: Expr Bool }
 
 -- | A Copilot specification is a list of streams, together with monitors on
 -- these streams implemented as observers, triggers or properties.
 data Spec = Spec
-  { specStreams      :: [Stream]
-  , specObservers    :: [Observer]
-  , specTriggers     :: [Trigger]
-  , specProperties   :: [Property] }
+  { specStreams    :: [Stream]
+  , specObservers  :: [Observer]
+  , specTriggers   :: [Trigger]
+  , specProperties :: [Property] }

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -14,12 +14,13 @@
 -- into Copilot Core's 'Spec'. This module defines the low-level Copilot Core
 -- representations for Specs and the main types of element in a spec..
 module Copilot.Core.Spec
-  ( Stream (..)
-  , Observer (..)
-  , Trigger (..)
-  , Spec (..)
-  , Property (..)
-  ) where
+    ( Stream (..)
+    , Observer (..)
+    , Trigger (..)
+    , Spec (..)
+    , Property (..)
+    )
+  where
 
 -- External imports
 import Data.Typeable (Typeable)

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -39,27 +39,31 @@ data Stream = forall a . (Typeable a, Typed a) => Stream
   { streamId       :: Id
   , streamBuffer   :: [a]
   , streamExpr     :: Expr a
-  , streamExprType :: Type a }
+  , streamExprType :: Type a
+  }
 
 -- | An observer, representing a stream that we observe during interpretation
 -- at every sample.
 data Observer = forall a . Typeable a => Observer
   { observerName     :: Name
   , observerExpr     :: Expr a
-  , observerExprType :: Type a }
+  , observerExprType :: Type a
+  }
 
 -- | A trigger, representing a function we execute when a boolean stream becomes
 -- true at a sample.
 data Trigger = Trigger
   { triggerName  :: Name
   , triggerGuard :: Expr Bool
-  , triggerArgs  :: [UExpr] }
+  , triggerArgs  :: [UExpr]
+  }
 
 -- | A property, representing a boolean stream that is existentially or
 -- universally quantified over time.
 data Property = Property
   { propertyName :: Name
-  , propertyExpr :: Expr Bool }
+  , propertyExpr :: Expr Bool
+  }
 
 -- | A Copilot specification is a list of streams, together with monitors on
 -- these streams implemented as observers, triggers or properties.
@@ -67,4 +71,5 @@ data Spec = Spec
   { specStreams    :: [Stream]
   , specObservers  :: [Observer]
   , specTriggers   :: [Trigger]
-  , specProperties :: [Property] }
+  , specProperties :: [Property]
+  }

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -23,23 +23,24 @@
 {-# LANGUAGE UndecidableInstances      #-}
 
 module Copilot.Core.Type
-  ( Type (..)
-  , Typed (..)
-  , UType (..)
-  , SimpleType (..)
+    ( Type (..)
+    , Typed (..)
+    , UType (..)
+    , SimpleType (..)
 
-  , tysize
-  , tylength
+    , tysize
+    , tylength
 
-  , Value (..)
-  , toValues
-  , Field (..)
-  , typename
+    , Value (..)
+    , toValues
+    , Field (..)
+    , typename
 
-  , Struct
-  , fieldname
-  , accessorname
-  ) where
+    , Struct
+    , fieldname
+    , accessorname
+    )
+  where
 
 -- External imports
 import Data.Int           (Int16, Int32, Int64, Int8)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -2,9 +2,9 @@
 -- Copilot.Core.Type.Equality does not give rise to warnings.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
--- | Typing for Core.
+-- |
+-- Description: Typing for Core.
+-- Copyright:   (c) 2011 National Institute of Aerospace / Galois, Inc.
 --
 -- All expressions and streams in Core are accompanied by a representation of
 -- the types of the underlying expressions used or carried by the streams.

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -41,11 +41,11 @@ module Copilot.Core.Type
   , accessorname
   ) where
 
-import Data.Int
-import Data.Word
+import Data.Int                   (Int16, Int32, Int64, Int8)
+import Data.Word                  (Word16, Word32, Word64, Word8)
 import Data.Type.Equality         as DE
 import Copilot.Core.Type.Equality as CE
-import Copilot.Core.Type.Array
+import Copilot.Core.Type.Array    (Array)
 
 import Data.Typeable (Typeable, typeRep)
 

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -41,18 +41,18 @@ module Copilot.Core.Type
   , accessorname
   ) where
 
-import Data.Int                   (Int16, Int32, Int64, Int8)
-import Data.Word                  (Word16, Word32, Word64, Word8)
-import Data.Type.Equality         as DE
-import Copilot.Core.Type.Equality as CE
+-- External imports
+import Data.Int           (Int16, Int32, Int64, Int8)
+import Data.List          (intercalate)
+import Data.Proxy         (Proxy (..))
+import Data.Type.Equality as DE
+import Data.Typeable      (Typeable, typeRep)
+import Data.Word          (Word16, Word32, Word64, Word8)
+import GHC.TypeLits       (KnownNat, KnownSymbol, Symbol, natVal, symbolVal)
+
+-- Internal imports
 import Copilot.Core.Type.Array    (Array)
-
-import Data.Typeable (Typeable, typeRep)
-
-import GHC.TypeLits (KnownNat, natVal, Symbol, KnownSymbol, symbolVal)
-import Data.Proxy   (Proxy (..))
-
-import Data.List (intercalate)
+import Copilot.Core.Type.Equality as CE
 
 -- | The value of that is a product or struct, defined as a constructor with
 -- several fields.

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -64,19 +64,19 @@ class Struct a where
   toValues :: a -> [Value a]
 
 -- | The field of a struct, together with a representation of its type.
-data Value a = forall s t. (Typeable t, KnownSymbol s, Show t) => Value (Type t) (Field s t)
+data Value a = forall s t . (Typeable t, KnownSymbol s, Show t) => Value (Type t) (Field s t)
 
 -- | A field in a struct. The name of the field is a literal at the type
 -- level.
 data Field (s :: Symbol) t = Field t
 
 -- | Extract the name of a field.
-fieldname :: forall s t. KnownSymbol s => Field s t -> String
+fieldname :: forall s t . KnownSymbol s => Field s t -> String
 fieldname _ = symbolVal (Proxy :: Proxy s)
 
 -- | Extract the name of an accessor (a function that returns a field of a
 -- struct).
-accessorname :: forall a s t. (Struct a, KnownSymbol s) => (a -> Field s t) -> String
+accessorname :: forall a s t . (Struct a, KnownSymbol s) => (a -> Field s t) -> String
 accessorname _ = symbolVal (Proxy :: Proxy s)
 
 instance (KnownSymbol s, Show t) => Show (Field s t) where
@@ -95,28 +95,28 @@ instance {-# OVERLAPPABLE #-} (Typed t, Struct t) => Show t where
 -- former, the length of the array is part of the type. In the latter, the
 -- names of the fields are part of the type.
 data Type :: * -> * where
-  Bool    :: Type Bool
-  Int8    :: Type Int8
-  Int16   :: Type Int16
-  Int32   :: Type Int32
-  Int64   :: Type Int64
-  Word8   :: Type Word8
-  Word16  :: Type Word16
-  Word32  :: Type Word32
-  Word64  :: Type Word64
-  Float   :: Type Float
-  Double  :: Type Double
-  Array   :: forall n t. ( KnownNat n
+  Bool   :: Type Bool
+  Int8   :: Type Int8
+  Int16  :: Type Int16
+  Int32  :: Type Int32
+  Int64  :: Type Int64
+  Word8  :: Type Word8
+  Word16 :: Type Word16
+  Word32 :: Type Word32
+  Word64 :: Type Word64
+  Float  :: Type Float
+  Double :: Type Double
+  Array  :: forall n t . ( KnownNat n
                          , Typed t
                          ) => Type t -> Type (Array n t)
-  Struct  :: (Typed a, Struct a) => a -> Type a
+  Struct :: (Typed a, Struct a) => a -> Type a
 
 -- | Return the length of an array from its type
-tylength :: forall n t. KnownNat n => Type (Array n t) -> Int
+tylength :: forall n t . KnownNat n => Type (Array n t) -> Int
 tylength _ = fromIntegral $ natVal (Proxy :: Proxy n)
 
 -- | Return the total (nested) size of an array from its type
-tysize :: forall n t. KnownNat n => Type (Array n t) -> Int
+tysize :: forall n t . KnownNat n => Type (Array n t) -> Int
 tysize ty@(Array ty'@(Array _)) = tylength ty * tysize ty'
 tysize ty@(Array _            ) = tylength ty
 
@@ -171,20 +171,20 @@ data SimpleType where
 -- This instance is necessary, otherwise the type of SArray can't be inferred.
 
 instance Eq SimpleType where
-  SBool   == SBool    = True
-  SInt8   == SInt8    = True
-  SInt16  == SInt16   = True
-  SInt32  == SInt32   = True
-  SInt64  == SInt64   = True
-  SWord8  == SWord8   = True
-  SWord16 == SWord16  = True
-  SWord32 == SWord32  = True
-  SWord64 == SWord64  = True
-  SFloat  == SFloat   = True
-  SDouble == SDouble  = True
+  SBool   == SBool   = True
+  SInt8   == SInt8   = True
+  SInt16  == SInt16  = True
+  SInt32  == SInt32  = True
+  SInt64  == SInt64  = True
+  SWord8  == SWord8  = True
+  SWord16 == SWord16 = True
+  SWord32 == SWord32 = True
+  SWord64 == SWord64 = True
+  SFloat  == SFloat  = True
+  SDouble == SDouble = True
   (SArray t1) == (SArray t2) | Just DE.Refl <- testEquality t1 t2 = True
                              | otherwise                          = False
-  SStruct == SStruct  = True
+  SStruct == SStruct = True
   _ == _ = False
 
 -- | A typed expression, from which we can obtain the two type representations
@@ -194,22 +194,22 @@ class (Show a, Typeable a) => Typed a where
   simpleType :: Type a -> SimpleType
   simpleType _ = SStruct
 
-instance Typed Bool   where
+instance Typed Bool where
   typeOf       = Bool
   simpleType _ = SBool
-instance Typed Int8   where
+instance Typed Int8 where
   typeOf       = Int8
   simpleType _ = SBool
-instance Typed Int16  where
+instance Typed Int16 where
   typeOf       = Int16
   simpleType _ = SInt16
-instance Typed Int32  where
+instance Typed Int32 where
   typeOf       = Int32
   simpleType _ = SInt32
-instance Typed Int64  where
+instance Typed Int64 where
   typeOf       = Int64
   simpleType _ = SInt64
-instance Typed Word8  where
+instance Typed Word8 where
   typeOf       = Word8
   simpleType _ = SWord8
 instance Typed Word16 where
@@ -221,15 +221,15 @@ instance Typed Word32 where
 instance Typed Word64 where
   typeOf       = Word64
   simpleType _ = SWord64
-instance Typed Float  where
+instance Typed Float where
   typeOf       = Float
   simpleType _ = SFloat
 instance Typed Double where
   typeOf       = Double
   simpleType _ = SDouble
 instance (Typeable t, Typed t, KnownNat n) => Typed (Array n t) where
-  typeOf                = Array typeOf
-  simpleType (Array t)  = SArray t
+  typeOf               = Array typeOf
+  simpleType (Array t) = SArray t
 
 -- | A untyped type (no phantom type).
 data UType = forall a . Typeable a => UType { uTypeType :: Type a }

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -1,3 +1,13 @@
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE Safe                      #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE UndecidableInstances      #-}
+
 -- The following flag is disabled in this module so that the import of
 -- Copilot.Core.Type.Equality does not give rise to warnings.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
@@ -11,17 +21,6 @@
 -- This information is needed by the compiler to generate code, since it must
 -- initialize variables and equivalent representations for those types in
 -- the target languages.
-
-{-# LANGUAGE DataKinds                 #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE KindSignatures            #-}
-{-# LANGUAGE Safe                      #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE UndecidableInstances      #-}
-
 module Copilot.Core.Type
     ( Type (..)
     , Typed (..)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -63,7 +63,8 @@ class Struct a where
   toValues :: a -> [Value a]
 
 -- | The field of a struct, together with a representation of its type.
-data Value a = forall s t . (Typeable t, KnownSymbol s, Show t) => Value (Type t) (Field s t)
+data Value a =
+  forall s t . (Typeable t, KnownSymbol s, Show t) => Value (Type t) (Field s t)
 
 -- | A field in a struct. The name of the field is a literal at the type
 -- level.
@@ -75,7 +76,8 @@ fieldname _ = symbolVal (Proxy :: Proxy s)
 
 -- | Extract the name of an accessor (a function that returns a field of a
 -- struct).
-accessorname :: forall a s t . (Struct a, KnownSymbol s) => (a -> Field s t) -> String
+accessorname :: forall a s t . (Struct a, KnownSymbol s)
+             => (a -> Field s t) -> String
 accessorname _ = symbolVal (Proxy :: Proxy s)
 
 instance (KnownSymbol s, Show t) => Show (Field s t) where

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -197,36 +197,47 @@ class (Show a, Typeable a) => Typed a where
 instance Typed Bool where
   typeOf       = Bool
   simpleType _ = SBool
+
 instance Typed Int8 where
   typeOf       = Int8
   simpleType _ = SBool
+
 instance Typed Int16 where
   typeOf       = Int16
   simpleType _ = SInt16
+
 instance Typed Int32 where
   typeOf       = Int32
   simpleType _ = SInt32
+
 instance Typed Int64 where
   typeOf       = Int64
   simpleType _ = SInt64
+
 instance Typed Word8 where
   typeOf       = Word8
   simpleType _ = SWord8
+
 instance Typed Word16 where
   typeOf       = Word16
   simpleType _ = SWord16
+
 instance Typed Word32 where
   typeOf       = Word32
   simpleType _ = SWord32
+
 instance Typed Word64 where
   typeOf       = Word64
   simpleType _ = SWord64
+
 instance Typed Float where
   typeOf       = Float
   simpleType _ = SFloat
+
 instance Typed Double where
   typeOf       = Double
   simpleType _ = SDouble
+
 instance (Typeable t, Typed t, KnownNat n) => Typed (Array n t) where
   typeOf               = Array typeOf
   simpleType (Array t) = SArray t

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -168,7 +168,6 @@ data SimpleType where
 -- | Type equality, used to help type inference.
 
 -- This instance is necessary, otherwise the type of SArray can't be inferred.
-
 instance Eq SimpleType where
   SBool   == SBool   = True
   SInt8   == SInt8   = True

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe                  #-}
 {-# LANGUAGE ScopedTypeVariables   #-}

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -13,7 +13,6 @@
 -- Implementation of an array that uses type literals to store length. No
 -- explicit indexing is used for the input data. Supports arbitrary nesting of
 -- arrays.
-
 module Copilot.Core.Type.Array
     ( Array
     , array

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -15,14 +15,15 @@
 -- arrays.
 
 module Copilot.Core.Type.Array
-  ( Array
-  , array
-  , flatten
-  , size
-  , Flatten
-  , InnerType
-  , arrayelems
-  ) where
+    ( Array
+    , array
+    , flatten
+    , size
+    , Flatten
+    , InnerType
+    , arrayelems
+    )
+  where
 
 -- External imports
 import Data.Proxy   (Proxy (..))

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -24,8 +24,9 @@ module Copilot.Core.Type.Array
   , arrayelems
   ) where
 
-import GHC.TypeLits     (Nat, KnownNat, natVal)
-import Data.Proxy       (Proxy (..))
+-- External imports
+import Data.Proxy   (Proxy (..))
+import GHC.TypeLits (KnownNat, Nat, natVal)
 
 -- | Implementation of an array that uses type literals to store length.
 data Array (n :: Nat) t where

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -1,5 +1,3 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
@@ -9,7 +7,10 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 
--- | Implementation of an array that uses type literals to store length. No
+-- |
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Implementation of an array that uses type literals to store length. No
 -- explicit indexing is used for the input data. Supports arbitrary nesting of
 -- arrays.
 

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -1,10 +1,11 @@
--- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE Safe                      #-}
 
--- | Show Copilot Core types and typed values.
+-- |
+-- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
+--
+-- Show Copilot Core types and typed values.
 module Copilot.Core.Type.ShowInternal
     ( showWithType
     , ShowType(..)

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -8,7 +8,7 @@
 -- Show Copilot Core types and typed values.
 module Copilot.Core.Type.ShowInternal
     ( showWithType
-    , ShowType(..)
+    , ShowType (..)
     , showType
     )
   where
@@ -42,18 +42,18 @@ showWithType showT t x =
 showType :: Type a -> String
 showType t =
   case t of
-    Bool   -> "Bool"
-    Int8   -> "Int8"
-    Int16  -> "Int16"
-    Int32  -> "Int32"
-    Int64  -> "Int64"
-    Word8  -> "Word8"
-    Word16 -> "Word16"
-    Word32 -> "Word32"
-    Word64 -> "Word64"
-    Float  -> "Float"
-    Double -> "Double"
-    Array t -> "Array " ++ showType t
+    Bool     -> "Bool"
+    Int8     -> "Int8"
+    Int16    -> "Int16"
+    Int32    -> "Int32"
+    Int64    -> "Int64"
+    Word8    -> "Word8"
+    Word16   -> "Word16"
+    Word32   -> "Word32"
+    Word64   -> "Word64"
+    Float    -> "Float"
+    Double   -> "Double"
+    Array t  -> "Array " ++ showType t
     Struct t -> "Struct"
 
 -- * Auxiliary show instance
@@ -65,16 +65,16 @@ data ShowWit a = Show a => ShowWit
 showWit :: Type a -> ShowWit a
 showWit t =
   case t of
-    Bool   -> ShowWit
-    Int8   -> ShowWit
-    Int16  -> ShowWit
-    Int32  -> ShowWit
-    Int64  -> ShowWit
-    Word8  -> ShowWit
-    Word16 -> ShowWit
-    Word32 -> ShowWit
-    Word64 -> ShowWit
-    Float  -> ShowWit
-    Double -> ShowWit
-    Array t -> ShowWit
+    Bool     -> ShowWit
+    Int8     -> ShowWit
+    Int16    -> ShowWit
+    Int32    -> ShowWit
+    Int64    -> ShowWit
+    Word8    -> ShowWit
+    Word16   -> ShowWit
+    Word32   -> ShowWit
+    Word64   -> ShowWit
+    Float    -> ShowWit
+    Double   -> ShowWit
+    Array t  -> ShowWit
     Struct t -> ShowWit

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -16,9 +16,6 @@ module Copilot.Core.Type.ShowInternal
 -- Internal imports
 import Copilot.Core.Type (Type (..))
 
--- Are we proving equivalence with a C backend, in which case we want to show
--- Booleans as '0' and '1'.
-
 -- | Target language for showing a typed value. Used to adapt the
 -- representation of booleans.
 data ShowType = C | Haskell

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -11,6 +11,7 @@ module Copilot.Core.Type.ShowInternal
   , showType
   ) where
 
+-- Internal imports
 import Copilot.Core.Type (Type (..))
 
 -- Are we proving equivalence with a C backend, in which case we want to show

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -6,10 +6,11 @@
 
 -- | Show Copilot Core types and typed values.
 module Copilot.Core.Type.ShowInternal
-  ( showWithType
-  , ShowType(..)
-  , showType
-  ) where
+    ( showWithType
+    , ShowType(..)
+    , showType
+    )
+  where
 
 -- Internal imports
 import Copilot.Core.Type (Type (..))
@@ -25,16 +26,16 @@ data ShowType = C | Haskell
 -- language. Booleans are represented differently depending on the backend.
 showWithType :: ShowType -> Type a -> a -> String
 showWithType showT t x =
-  case showT of
-    C         -> case t of
+    case showT of
+      C       -> case t of
                    Bool -> if x then "1" else "0"
                    _    -> sw
-    Haskell   -> case t of
+      Haskell -> case t of
                    Bool -> if x then "true" else "false"
                    _    -> sw
   where
-  sw = case showWit t of
-         ShowWit -> show x
+    sw = case showWit t of
+           ShowWit -> show x
 
 -- | Show Copilot Core type.
 showType :: Type a -> String

--- a/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
+++ b/copilot-core/src/Copilot/Core/Type/ShowInternal.hs
@@ -11,7 +11,7 @@ module Copilot.Core.Type.ShowInternal
   , showType
   ) where
 
-import Copilot.Core.Type
+import Copilot.Core.Type (Type (..))
 
 -- Are we proving equivalence with a C backend, in which case we want to show
 -- Booleans as '0' and '1'.


### PR DESCRIPTION
Adjust code in `copilot-core` to conform to style guide, as prescribed in the solution proposed for #332.