### PR TITLE
`copilot-core`: Fix error in `simpleType` definition for `Int8`

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2022-12-27
+        * Fix bug in definition of simpleType for Int8. (#393)
+
 2022-11-07
         * Version bump (3.12). (#389)
         * Deprecate Copilot.Core.PrettyPrinter. (#383)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -200,7 +200,7 @@ instance Typed Bool where
 
 instance Typed Int8 where
   typeOf       = Int8
-  simpleType _ = SBool
+  simpleType _ = SInt8
 
 instance Typed Int16 where
   typeOf       = Int16


### PR DESCRIPTION
Modify `Copilot.Core.Type.simpleType` instance definition for `Int8` so that it returns `SInt8`, and add a test that will catch that and similar kinds of errors in that function, as prescribed in the solution proposed for #393 .