### PR TITLE
`copilot-core`: Implement missing cases of type equality for arrays and structs. Refs #400.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,7 @@
+2023-01-04
+        * Implement missing cases of type equality for arrays and structs.
+          (#400)
+
 2022-12-27
         * Remove Copilot.Core.External. (#391)
         * Fix bug in definition of simpleType for Int8. (#393)


### PR DESCRIPTION
The `TestEquality Type` instance is used as part of the code which checks to see if an `extern` has been declared to have two different types. This instance lacked cases for `Array` and `Struct` types, which meant that `copilot` would incorrectly believe that a nested array type (e.g., `Array 2 (Array 2 Int16)` or `Array 2 StructType`) was not equal to itself, leading to `extern`s with that type erroneously being rejected.

This patch adds the missing `Array` and `Struct` cases to the `TestEquality` instance. This proves relatively straightfoward:

* `Array n1 a1` equals `Array n2 a2` iff `n1` equals `n2` and `a1` equals `a2`.
* Two `Struct` types are equal iff they are equal according to their `Typeable` instances.

There is a very similar `EqualType Type` instance that also lacks cases for `Array` and `Struct`. This patch does not change the `EqualType Type` instance, however, for two reasons:

1. The `EqualType` class is defined in the `Copilot.Core.Type.Equality` module, which is deprecated.
2. This instance is not used anywhere in the `copilot` ecosystem.