### PR TITLE
`copilot-c99`: Declare local array variables in generated guards as pointers. Refs #401.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2023-01-07
+        * Declare local array variables in generated guards as pointers. (#401)
+
 2022-11-07
         * Version bump (3.12). (#389)
         * Removed deprecated flag from cabal file. (#380)


### PR DESCRIPTION
Modify the translation of `local` by the C99 backend such that it uses a pointer for the outermost type of an array, as prescribed in the solution proposed for #401.

