### PR TITLE
`copilot-c99`: Use pointer to pass output array as argument to generators. Refs #386.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
 2023-01-07
         * Declare local array variables in generated guards as pointers. (#401)
+        * Use pointer to pass output array as argument to generators. (#386)
 
 2022-11-07
         * Version bump (3.12). (#389)

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 -- | Compile Copilot specifications to C99 code.
 module Copilot.Compile.C99.Compile
   ( compile
@@ -103,6 +104,8 @@ compilec cSettings spec = C.TransUnit declns funs
         accessdecln (Stream sid buff _ ty) = mkaccessdecln sid ty buff
 
         streamgen :: Stream -> C.FunDef
+        streamgen (Stream sid _ expr ty@(Array _)) =
+          genFunArray (generatorname sid) (generatorOutputArgName sid) expr ty
         streamgen (Stream sid _ expr ty) = genfun (generatorname sid) expr ty
 
         triggergen :: Trigger -> [C.FunDef]

--- a/copilot-c99/src/Copilot/Compile/C99/Util.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Util.hs
@@ -47,6 +47,10 @@ excpyname name = name ++ "_cpy"
 generatorname :: Id -> String
 generatorname sid = streamname sid ++ "_gen"
 
+-- | Turn stream id into name of its output argument array.
+generatorOutputArgName :: Id -> String
+generatorOutputArgName sid = streamname sid ++ "_output"
+
 -- | Turn the name of a trigger into a guard generator.
 guardname :: String -> String
 guardname name = name ++ "_guard"


### PR DESCRIPTION
Modify generated C99 backend so that the output arrays of generator functions take the array as an input argument, as prescribed in the solution proposed for #386.