### PR TITLE
`copilot-core`: Fix formatting error in CHANGELOG. Refs #414.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,5 +1,6 @@
-2023-02-07
+2023-02-17
         * Remove Copilot.Core.PrettyDot. (#409)
+        * Fix formatting error in CHANGELOG. (#414)
 
 2023-01-07
         * Version bump (3.13). (#406)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -5,8 +5,6 @@
         * Version bump (3.13). (#406)
         * Implement missing cases of type equality for arrays and structs.
           (#400)
-
-2022-12-27
         * Remove Copilot.Core.External. (#391)
         * Fix bug in definition of simpleType for Int8. (#393)
         * Hide module Copilot.Core.Type.Show. (#392)


### PR DESCRIPTION
Merge entries in CHANGELOG of `copilot-core` for the dates 2023-01-07 and 2022-12-27, as prescribed in the solution proposed for #414.