### PR TITLE
`copilot-language`: Remove function Copilot.Language.prettyPrint. Refs #412.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2023-02-21
+        * Remove function Copilot.Language.prettyPrint. (#412)
+
 2023-01-07
         * Version bump (3.13). (#406)
 

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -44,7 +44,6 @@ library
 
                , copilot-core          >= 3.13 && < 3.14
                , copilot-interpreter   >= 3.13 && < 3.14
-               , copilot-prettyprinter >= 3.13 && < 3.14
                , copilot-theorem       >= 3.13 && < 3.14
 
   exposed-modules: Copilot.Language

--- a/copilot-language/src/Copilot/Language.hs
+++ b/copilot-language/src/Copilot/Language.hs
@@ -39,7 +39,6 @@ module Copilot.Language
   , prop
   , theorem
   , forall, exists
-  , prettyPrint
   ) where
 
 import Data.Int hiding (Int)
@@ -67,10 +66,3 @@ import Copilot.Language.Reify
 import Copilot.Language.Prelude
 import Copilot.Language.Spec
 import Copilot.Language.Stream (Stream)
-import qualified Copilot.PrettyPrint as PP
-
--- | Transform a high-level Copilot Language specification into a low-level
--- Copilot Core specification and pretty-print it to stdout.
-{-# DEPRECATED prettyPrint "This function is deprecated in Copilot 3.11." #-}
-prettyPrint :: Spec -> IO ()
-prettyPrint e = fmap PP.prettyPrint (reify e) >>= putStr

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2023-02-21
+        * Replace import of Copilot.Language.prettyPrint. (#412)
+
 2023-01-07
         * Version bump (3.13). (#406)
 

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -47,16 +47,17 @@ library
       -Wall
       -fno-warn-orphans
     build-depends:
-                       base                 >= 4.9  && < 5
-                     , optparse-applicative >= 0.14 && < 0.18
-                     , directory            >= 1.3  && < 1.4
-                     , filepath             >= 1.4  && < 1.5
+                       base                  >= 4.9  && < 5
+                     , optparse-applicative  >= 0.14 && < 0.18
+                     , directory             >= 1.3  && < 1.4
+                     , filepath              >= 1.4  && < 1.5
 
-                     , copilot-core         >= 3.13 && < 3.14
-                     , copilot-theorem      >= 3.13 && < 3.14
-                     , copilot-language     >= 3.13 && < 3.14
-                     , copilot-libraries    >= 3.13 && < 3.14
-                     , copilot-c99          >= 3.13 && < 3.14
+                     , copilot-core          >= 3.13 && < 3.14
+                     , copilot-theorem       >= 3.13 && < 3.14
+                     , copilot-language      >= 3.13 && < 3.14
+                     , copilot-libraries     >= 3.13 && < 3.14
+                     , copilot-c99           >= 3.13 && < 3.14
+                     , copilot-prettyprinter >= 3.13 && < 3.14
 
 
     exposed-modules: Language.Copilot, Language.Copilot.Main

--- a/copilot/src/Language/Copilot/Main.hs
+++ b/copilot/src/Language/Copilot/Main.hs
@@ -3,9 +3,10 @@
 module Language.Copilot.Main ( copilotMain, defaultMain ) where
 
 import qualified Copilot.Core as C (Spec)
-import Copilot.Language (interpret, prettyPrint)
+import Copilot.Language (interpret)
 import Copilot.Language.Reify (reify)
 import Copilot.Language (Spec)
+import qualified Copilot.PrettyPrint as PP
 
 import Options.Applicative
 import Data.Semigroup ((<>))
@@ -86,3 +87,8 @@ copilotMain interp pretty comp spec = main =<< execParser opts
 -- command line options.
 defaultMain :: Compiler -> Spec -> IO ()
 defaultMain = copilotMain interpret prettyPrint
+  where
+    -- Transform a high-level Copilot Language specification into a low-level
+    -- Copilot Core specification and pretty-print it to stdout.
+    prettyPrint :: Spec -> IO ()
+    prettyPrint e = fmap PP.prettyPrint (reify e) >>= putStr


### PR DESCRIPTION
The function `Copilot.Language.prettyPrint` was deprecated in 3.11 and is now fully removed, as prescribed in the solution proposed for #412.