### PR TITLE
`copilot-core`: Remove `InnerType`, `Flatten`, `Foldable` instance, `size` from `Copilot.Core.Type.Array`. Refs #411.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -2,6 +2,7 @@
         * Remove Copilot.Core.PrettyDot. (#409)
         * Fix formatting error in CHANGELOG. (#414)
         * Remove module space Copilot.Core.Interpret. (#410)
+        * Remove unused definitions from Copilot.Core.Type.Array. (#411)
 
 2023-01-07
         * Version bump (3.13). (#406)

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -1,11 +1,8 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Safe                  #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE Safe                #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- |
 -- Copyright: (c) 2011 National Institute of Aerospace / Galois, Inc.
@@ -16,10 +13,6 @@
 module Copilot.Core.Type.Array
     ( Array
     , array
-    , flatten
-    , size
-    , Flatten
-    , InnerType
     , arrayelems
     )
   where
@@ -45,36 +38,6 @@ array xs | datalen == typelen = Array xs
     typelen = fromIntegral $ natVal (Proxy :: Proxy n)
     errmsg = "Length of data (" ++ show datalen ++
              ") does not match length of type (" ++ show typelen ++ ")."
-
--- | Association between an array and the type of the elements it contains.
-{-# DEPRECATED InnerType "This type family is deprecated in Copilot 3.11." #-}
-type family InnerType x where
-  InnerType (Array _ x) = InnerType x
-  InnerType x           = x
-
--- | Flattening or conversion of arrays to lists.
-{-# DEPRECATED Flatten "This class is deprecated in Copilot 3.11." #-}
-{-# DEPRECATED flatten "This function is deprecated in Copilot 3.11." #-}
-class Flatten a b where
-  -- | Flatten an array to a list.
-  flatten :: Array n a -> [b]
-
--- | Flattening of plain arrays.
-instance Flatten a a where
-  flatten (Array xs) = xs
-
--- | Flattening of nested arrays.
-instance Flatten a b => Flatten (Array n a) b where
-  flatten (Array xss) = concat $ map flatten xss
-
--- | This instance is deprecated in Copilot 3.11.
-instance Foldable (Array n) where
-  foldr f base (Array xs) = foldr f base xs
-
--- | Total number of elements in a possibly nested array.
-{-# DEPRECATED size "This function is deprecated in Copilot 3.11." #-}
-size :: forall a n b. (Flatten a b, b ~ InnerType a) => Array n a -> Int
-size xs = length $ (flatten xs :: [b])
 
 -- | Return the elemts of an array.
 arrayelems :: Array n a -> [a]

--- a/copilot-core/tests/Test/Copilot/Core/Type/Array.hs
+++ b/copilot-core/tests/Test/Copilot/Core/Type/Array.hs
@@ -13,7 +13,7 @@ import Test.QuickCheck                      (Gen, Property, arbitrary, forAll,
                                              vectorOf)
 
 -- Internal imports: library modules being tested
-import Copilot.Core.Type.Array (Array, array, arrayelems, flatten, size)
+import Copilot.Core.Type.Array (Array, array, arrayelems)
 
 -- | All unit tests for copilot-core:Copilot.Core.Array.
 tests :: Test.Framework.Test
@@ -25,30 +25,6 @@ tests =
         (testArrayElemsLeft (Proxy :: Proxy 5))
     , testProperty "arrayElems . array (identity; 200)"
         (testArrayElemsLeft (Proxy :: Proxy 200))
-    , testProperty "arrayFlatten . array (identity; 0)"
-        (testArrayFlattenLeft (Proxy :: Proxy 0))
-    , testProperty "arrayFlatten . array (identity; 1)"
-        (testArrayFlattenLeft (Proxy :: Proxy 1))
-    , testProperty "arrayFlatten . array (identity; 2)"
-        (testArrayFlattenLeft (Proxy :: Proxy 2))
-    , testProperty "arrayFlatten . array (identity; 22)"
-        (testArrayFlattenLeft (Proxy :: Proxy 22))
-    , testProperty "arrayFlatten . array (identity; 50)"
-        (testArrayFlattenLeft (Proxy :: Proxy 50))
-    , testProperty "arrayFlatten . array (identity; nested; nested; 2x6)"
-        (testArrayFlattenNestedLeft (Proxy :: Proxy 2) (Proxy :: Proxy 6))
-    , testProperty "arrayFlatten . array (identity; nested; nested; 10x2)"
-        (testArrayFlattenNestedLeft (Proxy :: Proxy 10) (Proxy :: Proxy 2))
-    , testProperty "arrayFlatten . array (identity; nested; nested; 38x20)"
-        (testArrayFlattenNestedLeft (Proxy :: Proxy 38) (Proxy :: Proxy 20))
-    , testProperty "arrayFlatten . array (identity; nested; nested; 125x100)"
-        (testArrayFlattenNestedLeft (Proxy :: Proxy 125) (Proxy :: Proxy 100))
-    , testProperty "arraySize . array (identity; 0)"
-        (testArraySizeLeft (Proxy :: Proxy 0))
-    , testProperty "arraySize . array (identity; 45)"
-        (testArraySizeLeft (Proxy :: Proxy 45))
-    , testProperty "arraySize . array (identity; 100)"
-        (testArraySizeLeft (Proxy :: Proxy 100))
     ]
 
 -- * Individual tests
@@ -61,69 +37,6 @@ testArrayElemsLeft len =
       let array' :: Array n Int64
           array' = array ls
       in arrayelems array' == ls
-
-  where
-
-    -- Generator for lists of Int64 of known length.
-    xsInt64 :: Gen [Int64]
-    xsInt64 = vectorOf (fromIntegral (natVal len)) arbitrary
-
--- | Test that building an array from a list and extracting the elements with
--- the function 'flatten' will result in the same list.
---
--- This test tests only plain arrays (no nesting).
-testArrayFlattenLeft :: forall n . KnownNat n => Proxy n -> Property
-testArrayFlattenLeft len =
-    forAll xsInt64 $ \ls ->
-      let array' :: Array n Int64
-          array' = array ls
-      in flatten array' == ls
-
-  where
-
-    -- Generator for lists of Int64 of known length.
-    xsInt64 :: Gen [Int64]
-    xsInt64 = vectorOf (fromIntegral (natVal len)) arbitrary
-
--- | Test that building a nested array of a known size and extracting the
--- elements with the function 'flatten' will result in a list with a size that
--- is the product of the sizes provided.
-testArrayFlattenNestedLeft :: forall n1 n2
-                           .  (KnownNat n1, KnownNat n2)
-                           => Proxy n1
-                           -> Proxy n2
-                           -> Property
-testArrayFlattenNestedLeft len1 len2 =
-    forAll xsArrays $ \array' ->
-      length (flatten array' :: [Int64]) == expectedSize
-
-  where
-
-    -- Expected size of the matrix / array.
-    expectedSize :: Int
-    expectedSize = fromIntegral $ natVal len1 * natVal len2
-
-    -- Generator for nested matrices of Int64 of known size.
-    xsArrays :: Gen (Array n1 (Array n2 Int64))
-    xsArrays =
-      array <$> vectorOf (fromIntegral (natVal len1)) xsArrayInt64
-
-    -- Generator for arrays of Int64 of known length.
-    xsArrayInt64 :: Gen (Array n2 Int64)
-    xsArrayInt64 = array <$> xsInt64
-
-    -- Generator for lists of Int64 of known length.
-    xsInt64 :: Gen [Int64]
-    xsInt64 = vectorOf (fromIntegral (natVal len2)) arbitrary
-
--- | Test that building an array from a list and calculating the size will
--- return the length of the list.
-testArraySizeLeft :: forall n . KnownNat n => Proxy n -> Property
-testArraySizeLeft len =
-    forAll xsInt64 $ \ls ->
-      let array' :: Array n Int64
-          array' = array ls
-      in size array' == length ls
 
   where
 


### PR DESCRIPTION
Remove  `InnerType`, `Flatten`, `Foldable` instance, `size` from `Copilot.Core.Type.Array`, as well as the test of those functions, as prescribed in the solution proposed for #411.