### PR TITLE
Extend range of versions of dependencies. Refs #423.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,5 +1,6 @@
-2023-02-21
+2023-03-07
         * Remove function Copilot.Language.prettyPrint. (#412)
+        * Adjust to work with GHC 9.4. (#423)
 
 2023-01-07
         * Version bump (3.13). (#406)

--- a/copilot-language/src/Copilot/Language/Operators/BitWise.hs
+++ b/copilot-language/src/Copilot/Language/Operators/BitWise.hs
@@ -1,5 +1,6 @@
 -- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
 
+{-# LANGUAGE CPP  #-}
 {-# LANGUAGE Safe #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -16,7 +17,12 @@ import Copilot.Core (Typed, typeOf)
 import qualified Copilot.Core as Core
 import Copilot.Language.Stream
 import qualified Prelude as P
+
+#if MIN_VERSION_base(4,17,0)
+import Data.Bits hiding ((.>>.), (.<<.))
+#else
 import Data.Bits
+#endif
 
 -- | Instance of the 'Bits' class for 'Stream's.
 --
@@ -36,9 +42,11 @@ instance (Typed a, Bits a) => Bits (Stream a) where
   bit          = P.error "tbd: bit"
   popCount     = P.error "tbd: popCount"
 
+#if !MIN_VERSION_base(4,17,0)
 -- | See 'xor'.
 (.^.) :: Bits a => a -> a -> a
 (.^.) = xor -- Avoid redefinition of the Operators.Boolean xor
+#endif
 
 -- | Shifting values of a stream to the left.
 (.<<.) :: (Bits a, Typed a, Typed b, P.Integral b)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2023-03-07
+        * Adjust contraints on version of what4. (#423)
+
 2023-01-07
         * Version bump (3.13). (#406)
 

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -61,7 +61,7 @@ library
                           , random                >= 1.1 && < 1.3
                           , transformers          >= 0.5 && < 0.7
                           , xml                   >= 1.3 && < 1.4
-                          , what4                 >= 1.3 && < 1.4
+                          , what4                 >= 1.3 && < 1.5
 
                           , copilot-core          >= 3.13 && < 3.14
                           , copilot-prettyprinter >= 3.13 && < 3.14

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,6 +1,7 @@
 2023-03-07
         * Replace import of Copilot.Language.prettyPrint. (#412)
         * Re-structure README. (#415)
+        * Update README to reflect support for GHC 9.4. (#423)
 
 2023-01-07
         * Version bump (3.13). (#406)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -81,7 +81,7 @@ ghci> ghci> Leaving GHCi.
 On other Linux distributions or older Debian-based distributions, to use
 Copilot you must install a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.2 as of this writing). You can install the toolchain using
+(9.4 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/) or, if you are on Debian/Ubuntu,
 directly with `apt-get`:
 
@@ -111,7 +111,7 @@ ghci> ghci> Leaving GHCi.
 
 To use Copilot you must have a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.2 as of this writing). You can install the toolchain using
+(9.4 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/), as well as with Homebrew:
 
 ```sh


### PR DESCRIPTION
Extend range of versions of dependencies supported, including what4 and GHC, as prescribed in the solution proposed for issue #423.