### PR TITLE
Add callstack support to copilot language data type constructors

### DIFF
--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -193,7 +193,7 @@ mkstep cSettings streams triggers exts =
     --    any modifications that the handler called makes to the struct argument
     --    will not affect the internals of the monitoring code.
     mktriggercheck :: Trigger -> ([C.Decln], C.Stmt)
-    mktriggercheck (Trigger name guard args) =
+    mktriggercheck (Trigger name guard args _) =
         (aTmpDeclns, ifStmt)
       where
         aTmpDeclns = zipWith (\tmpVar arg ->
@@ -285,7 +285,7 @@ gatherexprs streams triggers =  map streamexpr streams
                              ++ concatMap triggerexpr triggers
   where
     streamexpr  (Stream _ _ expr ty)   = UExpr ty expr
-    triggerexpr (Trigger _ guard args) = UExpr Bool guard : args
+    triggerexpr (Trigger _ guard args _) = UExpr Bool guard : args
 
 -- * Auxiliary functions
 

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -116,7 +116,7 @@ mkstep cSettings streams triggers exts =
 
     -- Write code to update global stream buffers and index.
     mkupdateglobals :: Stream -> (C.Decln, C.Stmt, C.Stmt, C.Stmt)
-    mkupdateglobals (Stream sid buff expr ty) =
+    mkupdateglobals (Stream sid buff expr ty _) =
       (tmpdecln, tmpassign, bufferupdate, indexupdate)
         where
           tmpdecln = C.VarDecln Nothing cty tmp_var Nothing
@@ -284,7 +284,7 @@ gatherexprs :: [Stream] -> [Trigger] -> [UExpr]
 gatherexprs streams triggers =  map streamexpr streams
                              ++ concatMap triggerexpr triggers
   where
-    streamexpr  (Stream _ _ expr ty)   = UExpr ty expr
+    streamexpr  (Stream _ _ expr ty _)   = UExpr ty expr
     triggerexpr (Trigger _ guard args _) = UExpr Bool guard : args
 
 -- * Auxiliary functions

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -109,7 +109,7 @@ compilec cSettings spec = C.TransUnit declns funs
         streamgen (Stream sid _ expr ty) = genfun (generatorname sid) expr ty
 
         triggergen :: Trigger -> [C.FunDef]
-        triggergen (Trigger name guard args) = guarddef : argdefs
+        triggergen (Trigger name guard args _) = guarddef : argdefs
           where
             guarddef = genfun (guardname name) guard Bool
             argdefs  = map arggen (zip (argnames name) args)
@@ -148,7 +148,7 @@ compileh cSettings spec = C.TransUnit declns []
     extfundeclns triggers = map extfundecln triggers
       where
         extfundecln :: Trigger -> C.Decln
-        extfundecln (Trigger name _ args) = C.FunDecln Nothing cty name params
+        extfundecln (Trigger name _ args _) = C.FunDecln Nothing cty name params
           where
             cty    = C.TypeSpec C.Void
             params = map mkparam $ zip (argnames name) args

--- a/copilot-c99/src/Copilot/Compile/C99/Compile.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Compile.hs
@@ -90,8 +90,8 @@ compilec cSettings spec = C.TransUnit declns funs
     mkglobals :: [Stream] -> [C.Decln]
     mkglobals streams = map buffdecln streams ++ map indexdecln streams
       where
-        buffdecln  (Stream sid buff _ ty) = mkbuffdecln  sid ty buff
-        indexdecln (Stream sid _    _ _ ) = mkindexdecln sid
+        buffdecln  (Stream sid buff _ ty _) = mkbuffdecln  sid ty buff
+        indexdecln (Stream sid _    _ _ _) = mkindexdecln sid
 
     -- Make generator functions, including trigger arguments.
     genfuns :: [Stream] -> [Trigger] -> [C.FunDef]
@@ -101,12 +101,12 @@ compilec cSettings spec = C.TransUnit declns funs
       where
 
         accessdecln :: Stream -> C.FunDef
-        accessdecln (Stream sid buff _ ty) = mkaccessdecln sid ty buff
+        accessdecln (Stream sid buff _ ty _) = mkaccessdecln sid ty buff
 
         streamgen :: Stream -> C.FunDef
-        streamgen (Stream sid _ expr ty@(Array _)) =
+        streamgen (Stream sid _ expr ty@(Array _) _) =
           genFunArray (generatorname sid) (generatorOutputArgName sid) expr ty
-        streamgen (Stream sid _ expr ty) = genfun (generatorname sid) expr ty
+        streamgen (Stream sid _ expr ty _) = genfun (generatorname sid) expr ty
 
         triggergen :: Trigger -> [C.FunDef]
         triggergen (Trigger name guard args _) = guarddef : argdefs

--- a/copilot-c99/src/Copilot/Compile/C99/External.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/External.hs
@@ -35,7 +35,7 @@ gatherexts streams triggers = streamsexts `extunion` triggersexts
     streamexts (Stream _ _ expr _) = exprexts expr
 
     triggerexts :: Trigger -> [External]
-    triggerexts (Trigger _ guard args) = guardexts `extunion` argexts
+    triggerexts (Trigger _ guard args _) = guardexts `extunion` argexts
       where
         guardexts = exprexts guard
         argexts   = concat $ map uexprexts args

--- a/copilot-c99/src/Copilot/Compile/C99/External.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/External.hs
@@ -32,7 +32,7 @@ gatherexts streams triggers = streamsexts `extunion` triggersexts
     triggersexts = foldr extunion mempty $ map triggerexts triggers
 
     streamexts :: Stream -> [External]
-    streamexts (Stream _ _ expr _) = exprexts expr
+    streamexts (Stream _ _ expr _ _) = exprexts expr
 
     triggerexts :: Trigger -> [External]
     triggerexts (Trigger _ guard args _) = guardexts `extunion` argexts

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -41,6 +41,7 @@ data Stream = forall a . (Typeable a, Typed a) => Stream
   , streamBuffer   :: [a]
   , streamExpr     :: Expr a
   , streamExprType :: Type a
+  , streamCallStack :: CallStack
   }
 
 -- | An observer, representing a stream that we observe during interpretation

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -29,6 +29,7 @@ import Data.Typeable (Typeable)
 -- Internal imports
 import Copilot.Core.Expr (Expr, Id, Name, UExpr)
 import Copilot.Core.Type (Type, Typed)
+import GHC.Stack (CallStack)
 
 -- | A stream in an infinite succession of values of the same type.
 --
@@ -56,6 +57,7 @@ data Trigger = Trigger
   { triggerName  :: Name
   , triggerGuard :: Expr Bool
   , triggerArgs  :: [UExpr]
+  , triggerCallstack :: CallStack
   }
 
 -- | A property, representing a boolean stream that is existentially or

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -57,7 +57,7 @@ data Trigger = Trigger
   { triggerName  :: Name
   , triggerGuard :: Expr Bool
   , triggerArgs  :: [UExpr]
-  , triggerCallstack :: CallStack
+  , triggerCallStack :: CallStack
   }
 
 -- | A property, representing a boolean stream that is existentially or
@@ -65,7 +65,7 @@ data Trigger = Trigger
 data Property = Property
   { propertyName :: Name
   , propertyExpr :: Expr Bool
-  , propertyCallstack :: CallStack
+  , propertyCallStack :: CallStack
   }
 
 -- | A Copilot specification is a list of streams, together with monitors on

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -65,6 +65,7 @@ data Trigger = Trigger
 data Property = Property
   { propertyName :: Name
   , propertyExpr :: Expr Bool
+  , propertyCallstack :: CallStack
   }
 
 -- | A Copilot specification is a list of streams, together with monitors on

--- a/copilot-language/src/Copilot/Language/Analyze.hs
+++ b/copilot-language/src/Copilot/Language/Analyze.hs
@@ -92,7 +92,7 @@ analyze spec = do
 --
 -- This function can fail with one of the exceptions in 'AnalyzeException'.
 analyzeTrigger :: IORef Env -> Trigger -> IO ()
-analyzeTrigger refStreams (Trigger _ e0 args) =
+analyzeTrigger refStreams (Trigger _ e0 args _) =
   analyzeExpr refStreams e0 >> mapM_ analyzeTriggerArg args
 
   where
@@ -278,7 +278,7 @@ specExts refStreams spec = do
   observerExts env (Observer _ stream) = collectExts refStreams stream env
 
   triggerExts :: ExternEnv -> Trigger -> IO ExternEnv
-  triggerExts env (Trigger _ guard args) = do
+  triggerExts env (Trigger _ guard args _) = do
     env' <- collectExts refStreams guard env
     foldM (\env'' (Arg arg_) -> collectExts refStreams arg_ env'')
           env' args

--- a/copilot-language/src/Copilot/Language/Analyze.hs
+++ b/copilot-language/src/Copilot/Language/Analyze.hs
@@ -92,7 +92,7 @@ analyze spec = do
 --
 -- This function can fail with one of the exceptions in 'AnalyzeException'.
 analyzeTrigger :: IORef Env -> Trigger -> IO ()
-analyzeTrigger refStreams (Trigger _ e0 args _) =
+analyzeTrigger refStreams (Trigger _ e0 args) =
   analyzeExpr refStreams e0 >> mapM_ analyzeTriggerArg args
 
   where
@@ -109,7 +109,7 @@ analyzeObserver refStreams (Observer _ e) = analyzeExpr refStreams e
 --
 -- This function can fail with one of the exceptions in 'AnalyzeException'.
 analyzeProperty :: IORef Env -> Property -> IO ()
-analyzeProperty refStreams (Property _ e _) = analyzeExpr refStreams e
+analyzeProperty refStreams (Property _ e) = analyzeExpr refStreams e
 
 data SeenExtern = NoExtern
                 | SeenFun
@@ -278,7 +278,7 @@ specExts refStreams spec = do
   observerExts env (Observer _ stream) = collectExts refStreams stream env
 
   triggerExts :: ExternEnv -> Trigger -> IO ExternEnv
-  triggerExts env (Trigger _ guard args _) = do
+  triggerExts env (Trigger _ guard args) = do
     env' <- collectExts refStreams guard env
     foldM (\env'' (Arg arg_) -> collectExts refStreams arg_ env'')
           env' args

--- a/copilot-language/src/Copilot/Language/Analyze.hs
+++ b/copilot-language/src/Copilot/Language/Analyze.hs
@@ -109,7 +109,7 @@ analyzeObserver refStreams (Observer _ e) = analyzeExpr refStreams e
 --
 -- This function can fail with one of the exceptions in 'AnalyzeException'.
 analyzeProperty :: IORef Env -> Property -> IO ()
-analyzeProperty refStreams (Property _ e) = analyzeExpr refStreams e
+analyzeProperty refStreams (Property _ e _) = analyzeExpr refStreams e
 
 data SeenExtern = NoExtern
                 | SeenFun

--- a/copilot-language/src/Copilot/Language/Operators/Array.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Array.hs
@@ -16,6 +16,7 @@ import Copilot.Language.Stream  (Stream (..))
 
 import Data.Word                (Word32)
 import GHC.TypeLits             (KnownNat)
+import GHC.Stack (HasCallStack)
 
 -- | Create a stream that carries an element of an array in another stream.
 --
@@ -23,7 +24,8 @@ import GHC.TypeLits             (KnownNat)
 -- position, over time. For example, if @s@ is a stream of type @Stream (Array
 -- '5 Word8)@, then @s .!! 3@ has type @Stream Word8@ and contains the 3rd
 -- element (starting from zero) of the arrays in @s@ at any point in time.
-(.!!) :: ( KnownNat n
+(.!!) :: ( HasCallStack
+         , KnownNat n
          , Typed t
          ) => Stream (Array n t) -> Stream Word32 -> Stream t
 arr .!! n = Op2 (Index typeOf) arr n

--- a/copilot-language/src/Copilot/Language/Operators/BitWise.hs
+++ b/copilot-language/src/Copilot/Language/Operators/BitWise.hs
@@ -22,6 +22,7 @@ import qualified Prelude as P
 import Data.Bits hiding ((.>>.), (.<<.))
 #else
 import Data.Bits
+import GHC.Stack (HasCallStack)
 #endif
 
 -- | Instance of the 'Bits' class for 'Stream's.
@@ -49,11 +50,11 @@ instance (Typed a, Bits a) => Bits (Stream a) where
 #endif
 
 -- | Shifting values of a stream to the left.
-(.<<.) :: (Bits a, Typed a, Typed b, P.Integral b)
+(.<<.) :: (HasCallStack, Bits a, Typed a, Typed b, P.Integral b)
        => Stream a -> Stream b -> Stream a
 (.<<.) = Op2 (Core.BwShiftL typeOf typeOf)
 
 -- | Shifting values of a stream to the right.
-(.>>.) :: (Bits a, Typed a, Typed b, P.Integral b)
+(.>>.) :: (HasCallStack, Bits a, Typed a, Typed b, P.Integral b)
        => Stream a -> Stream b -> Stream a
 (.>>.) = Op2 (Core.BwShiftR typeOf typeOf)

--- a/copilot-language/src/Copilot/Language/Operators/Boolean.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Boolean.hs
@@ -18,19 +18,20 @@ import Copilot.Language.Prelude
 import Copilot.Language.Operators.Constant (constant)
 import Copilot.Language.Stream
 import qualified Prelude as P
+import GHC.Stack (HasCallStack)
 
 -- | A stream that contains the constant value 'True'.
-true :: Stream Bool
+true :: HasCallStack => Stream Bool
 true = constant True
 
 -- | A stream that contains the constant value 'False'.
-false :: Stream Bool
+false :: HasCallStack => Stream Bool
 false = constant False
 
 infixr 4 &&
 
 -- | Apply the and ('&&') operator to two boolean streams, point-wise.
-(&&) :: Stream Bool -> Stream Bool -> Stream Bool
+(&&) :: HasCallStack => Stream Bool -> Stream Bool -> Stream Bool
 (Const False) && _ = false
 _ && (Const False) = false
 (Const True) && y  = y
@@ -40,7 +41,7 @@ x && y             = Op2 Core.And x y
 infixr 4 ||
 
 -- | Apply the or ('||') operator to two boolean streams, point-wise.
-(||) :: Stream Bool -> Stream Bool -> Stream Bool
+(||) :: HasCallStack => Stream Bool -> Stream Bool -> Stream Bool
 (Const True) || _  = true
 _ || (Const True)  = true
 (Const False) || y = y
@@ -48,15 +49,15 @@ x || (Const False) = x
 x || y             = Op2 Core.Or x y
 
 -- | Negate all the values in a boolean stream.
-not :: Stream Bool -> Stream Bool
+not :: HasCallStack => Stream Bool -> Stream Bool
 not (Const c) = (Const $ P.not c)
 not x         = Op1 Core.Not x
 
 -- | Apply the exclusive-or ('xor') operator to two boolean streams,
 -- point-wise.
-xor :: Stream Bool -> Stream Bool -> Stream Bool
+xor :: HasCallStack => Stream Bool -> Stream Bool -> Stream Bool
 xor x y = ( not x && y ) || ( x && not y )
 
 -- | Apply the implication ('==>') operator to two boolean streams, point-wise.
-(==>) :: Stream Bool -> Stream Bool -> Stream Bool
+(==>) :: HasCallStack => Stream Bool -> Stream Bool -> Stream Bool
 x ==> y = not x || y

--- a/copilot-language/src/Copilot/Language/Operators/Cast.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Cast.hs
@@ -13,22 +13,23 @@ import Copilot.Language.Stream
 
 import Data.Int
 import Data.Word
+import GHC.Stack (HasCallStack)
 
 -- | Class to capture casting between types for which it can be performed
 -- safely.
 class Cast a b where
   -- | Perform a safe cast from @Stream a@ to @Stream b@.
-  cast :: (Typed a, Typed b) => Stream a -> Stream b
+  cast :: (HasCallStack, Typed a, Typed b) => Stream a -> Stream b
 
 -- | Class to capture casting between types for which casting may be unsafe
 -- and/or result in a loss of precision or information.
 class UnsafeCast a b where
   -- | Perform an unsafe cast from @Stream a@ to @Stream b@.
-  unsafeCast :: (Typed a, Typed b) => Stream a -> Stream b
+  unsafeCast :: (HasCallStack, Typed a, Typed b) => Stream a -> Stream b
 
 -- | Cast a boolean stream to a stream of numbers, producing 1 if the
 -- value at a point in time is 'True', and 0 otherwise.
-castBool :: (Eq a, Num a, Typed a) => Stream Bool -> Stream a
+castBool :: (HasCallStack, Eq a, Num a, Typed a) => Stream Bool -> Stream a
 castBool (Const bool) = Const $ if bool then 1 else 0
 castBool x            = Op3 (C.Mux typeOf) x 1 0
 
@@ -77,7 +78,7 @@ instance Cast Bool Int64 where
   cast = castBool
 
 -- | Cast a stream carrying numbers to an integral using 'fromIntegral'.
-castIntegral :: (Integral a, Typed a, Num b, Typed b) => Stream a -> Stream b
+castIntegral :: (HasCallStack, Integral a, Typed a, Num b, Typed b) => Stream a -> Stream b
 castIntegral (Const x) = Const (fromIntegral x)
 castIntegral x         = Op1 (C.Cast typeOf typeOf) x
 

--- a/copilot-language/src/Copilot/Language/Operators/Constant.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Constant.hs
@@ -23,63 +23,64 @@ import Copilot.Language.Stream
 
 import Data.Word
 import Data.Int
+import GHC.Stack (HasCallStack)
 
 -- | Create a constant stream that is equal to the given argument, at any
 -- point in time.
-constant :: Typed a => a -> Stream a
+constant :: (HasCallStack, Typed a) => a -> Stream a
 constant = Const
 
 -- | Create a constant stream carrying values of type 'Bool' that is equal to
 -- the given argument, at any point in time.
-constB :: Bool -> Stream Bool
+constB :: HasCallStack => Bool -> Stream Bool
 constB = constant
 
 -- | Create a constant stream carrying values of type 'Word8' that is equal to
 -- the given argument, at any point in time.
-constW8 :: Word8 -> Stream Word8
+constW8 :: HasCallStack => Word8 -> Stream Word8
 constW8 = constant
 
 -- | Create a constant stream carrying values of type 'Word16' that is equal to
 -- the given argument, at any point in time.
-constW16 :: Word16 -> Stream Word16
+constW16 :: HasCallStack => Word16 -> Stream Word16
 constW16 = constant
 
 -- | Create a constant stream carrying values of type 'Word32' that is equal to
 -- the given argument, at any point in time.
-constW32 :: Word32 -> Stream Word32
+constW32 :: HasCallStack => Word32 -> Stream Word32
 constW32 = constant
 
 -- | Create a constant stream carrying values of type 'Word64' that is equal to
 -- the given argument, at any point in time.
-constW64 :: Word64 -> Stream Word64
+constW64 :: HasCallStack => Word64 -> Stream Word64
 constW64 = constant
 
 -- | Create a constant stream carrying values of type 'Int8' that is equal to
 -- the given argument, at any point in time.
-constI8 :: Int8 -> Stream Int8
+constI8 :: HasCallStack => Int8 -> Stream Int8
 constI8 = constant
 
 -- | Create a constant stream carrying values of type 'Int16' that is equal to
 -- the given argument, at any point in time.
-constI16 :: Int16 -> Stream Int16
+constI16 :: HasCallStack => Int16 -> Stream Int16
 constI16 = constant
 
 -- | Create a constant stream carrying values of type 'Int32' that is equal to
 -- the given argument, at any point in time.
-constI32 :: Int32 -> Stream Int32
+constI32 :: HasCallStack => Int32 -> Stream Int32
 constI32 = constant
 
 -- | Create a constant stream carrying values of type 'Int64' that is equal to
 -- the given argument, at any point in time.
-constI64 :: Int64 -> Stream Int64
+constI64 :: HasCallStack => Int64 -> Stream Int64
 constI64 = constant
 
 -- | Create a constant stream carrying values of type 'Float' that is equal to
 -- the given argument, at any point in time.
-constF :: Float -> Stream Float
+constF :: HasCallStack => Float -> Stream Float
 constF = constant
 
 -- | Create a constant stream carrying values of type 'Double' that is equal to
 -- the given argument, at any point in time.
-constD :: Double -> Stream Double
+constD :: HasCallStack => Double -> Stream Double
 constD = constant

--- a/copilot-language/src/Copilot/Language/Operators/Eq.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Eq.hs
@@ -13,12 +13,13 @@ import qualified Copilot.Core as Core
 import Copilot.Language.Prelude
 import Copilot.Language.Stream
 import qualified Prelude as P
+import GHC.Stack (HasCallStack)
 
 -- | Compare two streams point-wise for equality.
 --
 -- The output stream contains the value True at a point in time if both
 -- argument streams contain the same value at that point in time.
-(==) :: (P.Eq a, Typed a) => Stream a -> Stream a -> Stream Bool
+(==) :: (HasCallStack, P.Eq a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) == (Const y) = Const (x P.== y)
 x == y = Op2 (Core.Eq typeOf) x y
 
@@ -26,6 +27,6 @@ x == y = Op2 (Core.Eq typeOf) x y
 --
 -- The output stream contains the value True at a point in time if both
 -- argument streams contain different values at that point in time.
-(/=) :: (P.Eq a, Typed a) => Stream a -> Stream a -> Stream Bool
+(/=) :: (HasCallStack, P.Eq a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) /= (Const y) = Const (x P./= y)
 x /= y = Op2 (Core.Ne typeOf) x y

--- a/copilot-language/src/Copilot/Language/Operators/Extern.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Extern.hs
@@ -23,6 +23,7 @@ import Copilot.Core (Typed)
 import Copilot.Language.Stream
 import Data.Word
 import Data.Int
+import GHC.Stack (HasCallStack)
 
 -- | Create a stream populated by an external global variable.
 --
@@ -32,7 +33,7 @@ import Data.Int
 -- of any type, which is potentially dangerous if the global variable mentioned
 -- has a different type. We rely on the compiler used with the generated code
 -- to detect type errors of this kind.
-extern :: Typed a
+extern :: (HasCallStack, Typed a)
        => String    -- ^ Name of the global variable to make accessible.
        -> Maybe [a] -- ^ Values to be used exclusively for testing/simulation.
        -> Stream a
@@ -40,7 +41,8 @@ extern = Extern
 
 -- | Create a stream carrying values of type Bool, populated by an external
 -- global variable.
-externB :: String       -- ^ Name of the global variable to make accessible.
+externB :: HasCallStack
+        => String       -- ^ Name of the global variable to make accessible.
         -> Maybe [Bool] -- ^ Values to be used exclusively for
                         -- testing/simulation.
         -> Stream Bool
@@ -48,7 +50,8 @@ externB = extern
 
 -- | Create a stream carrying values of type Word8, populated by an external
 -- global variable.
-externW8 :: String         -- ^ Name of the global variable to make accessible.
+externW8 :: HasCallStack
+         => String         -- ^ Name of the global variable to make accessible.
          -> Maybe [Word8]  -- ^ Values to be used exclusively for
                            --   testing/simulation.
          -> Stream Word8
@@ -56,7 +59,8 @@ externW8 = extern
 
 -- | Create a stream carrying values of type Word16, populated by an external
 -- global variable.
-externW16 :: String          -- ^ Name of the global variable to make accessible.
+externW16 :: HasCallStack
+          => String          -- ^ Name of the global variable to make accessible.
           -> Maybe [Word16]  -- ^ Values to be used exclusively for
                              -- testing/simulation.
           -> Stream Word16
@@ -64,7 +68,8 @@ externW16 = extern
 
 -- | Create a stream carrying values of type Word32, populated by an external
 -- global variable.
-externW32 :: String          -- ^ Name of the global variable to make accessible.
+externW32 :: HasCallStack
+          => String          -- ^ Name of the global variable to make accessible.
           -> Maybe [Word32]  -- ^ Values to be used exclusively for
                              -- testing/simulation.
           -> Stream Word32
@@ -72,7 +77,8 @@ externW32 = extern
 
 -- | Create a stream carrying values of type Word64, populated by an external
 -- global variable.
-externW64 :: String          -- ^ Name of the global variable to make accessible.
+externW64 :: HasCallStack
+          => String          -- ^ Name of the global variable to make accessible.
           -> Maybe [Word64]  -- ^ Values to be used exclusively for
                              -- testing/simulation.
           -> Stream Word64
@@ -80,42 +86,48 @@ externW64 = extern
 
 -- | Create a stream carrying values of type Int8, populated by an external
 -- global variable.
-externI8 :: String    -- ^ Name of the global variable to make accessible.
+externI8 :: HasCallStack
+          => String    -- ^ Name of the global variable to make accessible.
          -> Maybe [Int8] -- ^ Values to be used exclusively for testing/simulation.
          -> Stream Int8
 externI8 = extern
 
 -- | Create a stream carrying values of type Int16, populated by an external
 -- global variable.
-externI16 :: String    -- ^ Name of the global variable to make accessible.
+externI16 :: HasCallStack
+          => String    -- ^ Name of the global variable to make accessible.
           -> Maybe [Int16] -- ^ Values to be used exclusively for testing/simulation.
           -> Stream Int16
 externI16 = extern
 
 -- | Create a stream carrying values of type Int32, populated by an external
 -- global variable.
-externI32 :: String    -- ^ Name of the global variable to make accessible.
+externI32 :: HasCallStack
+          => String    -- ^ Name of the global variable to make accessible.
           -> Maybe [Int32] -- ^ Values to be used exclusively for testing/simulation.
           -> Stream Int32
 externI32 = extern
 
 -- | Create a stream carrying values of type Int64, populated by an external
 -- global variable.
-externI64 :: String    -- ^ Name of the global variable to make accessible.
+externI64 :: HasCallStack
+          => String    -- ^ Name of the global variable to make accessible.
           -> Maybe [Int64] -- ^ Values to be used exclusively for testing/simulation.
           -> Stream Int64
 externI64 = extern
 
 -- | Create a stream carrying values of type Float, populated by an external
 -- global variable.
-externF :: String        -- ^ Name of the global variable to make accessible.
+externF :: HasCallStack
+          => String        -- ^ Name of the global variable to make accessible.
         -> Maybe [Float] -- ^ Values to be used exclusively for testing/simulation.
         -> Stream Float
 externF = extern
 
 -- | Create a stream carrying values of type Double, populated by an external
 -- global variable.
-externD :: String    -- ^ Name of the global variable to make accessible.
+externD :: HasCallStack
+          => String    -- ^ Name of the global variable to make accessible.
         -> Maybe [Double] -- ^ Values to be used exclusively for testing/simulation.
         -> Stream Double
 externD = extern

--- a/copilot-language/src/Copilot/Language/Operators/Integral.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Integral.hs
@@ -19,16 +19,17 @@ import Copilot.Language.Stream
 import qualified Data.Bits as B
 import qualified Prelude as P
 import Data.List (foldl', replicate)
+import GHC.Stack (HasCallStack)
 
 -- | Apply the 'Prelude.div' operation to two streams, point-wise.
-div :: (Typed a, P.Integral a) => Stream a -> Stream a -> Stream a
+div :: (HasCallStack, Typed a, P.Integral a) => Stream a -> Stream a -> Stream a
 (Const 0) `div` _ = Const 0
 _ `div` (Const 0) = Err.badUsage "in div: division by zero."
 x `div` (Const 1) = x
 x `div` y = Op2 (Core.Div typeOf) x y
 
 -- | Apply the 'Prelude.mod' operation to two streams, point-wise.
-mod :: (Typed a, P.Integral a) => Stream a -> Stream a -> Stream a
+mod :: (HasCallStack, Typed a, P.Integral a) => Stream a -> Stream a -> Stream a
 _         `mod` (Const 0) = Err.badUsage "in mod: division by zero."
 (Const 0) `mod` _         = (Const 0)
 (Const x) `mod` (Const y) = Const (x `P.mod` y)
@@ -38,7 +39,7 @@ x `mod` y = Op2 (Core.Mod typeOf) x y
 --
 -- Either the first stream must be the constant 2, or the second must be a
 -- constant stream.
-(^) :: (Typed a, Typed b, P.Num a, B.Bits a, P.Integral b)
+(^) :: (HasCallStack, Typed a, Typed b, P.Num a, B.Bits a, P.Integral b)
     => Stream a -> Stream b -> Stream a
 (Const 0) ^ (Const 0)  = Const 1
 (Const 0) ^ x          = Op3 (Core.Mux typeOf) (Op2 (Core.Eq typeOf) x 0) (1) (0)

--- a/copilot-language/src/Copilot/Language/Operators/Label.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Label.hs
@@ -10,6 +10,7 @@ module Copilot.Language.Operators.Label
 
 import Copilot.Core (Typed)
 import Copilot.Language.Stream (Stream (..))
+import GHC.Stack (HasCallStack)
 
 -- | This function allows you to label a stream with a tag, which can be used
 -- by different backends to provide additional information either in error
@@ -18,5 +19,5 @@ import Copilot.Language.Stream (Stream (..))
 -- Semantically, a labelled stream is just the stream inside it. The use of
 -- label should not affect the observable behavior of the monitor, and how it
 -- is used in the code generated is a decision specific to each backend.
-label :: (Typed a) => String -> Stream a -> Stream a
+label :: (HasCallStack, Typed a) => String -> Stream a -> Stream a
 label = Label

--- a/copilot-language/src/Copilot/Language/Operators/Local.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Local.hs
@@ -15,6 +15,7 @@ module Copilot.Language.Operators.Local
 
 import Copilot.Core (Typed)
 import Copilot.Language.Stream (Stream (..))
+import GHC.Stack (HasCallStack)
 
 -- | Let expressions.
 --
@@ -27,5 +28,5 @@ import Copilot.Language.Stream (Stream (..))
 --   expression = local (stream1 + stream2) $ \\s ->
 --                (s >= 0 && s <= 10)
 --   @
-local :: (Typed a, Typed b) => Stream a -> (Stream a -> Stream b) -> Stream b
+local :: (HasCallStack, Typed a, Typed b) => Stream a -> (Stream a -> Stream b) -> Stream b
 local = Local

--- a/copilot-language/src/Copilot/Language/Operators/Mux.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Mux.hs
@@ -14,9 +14,10 @@ import qualified Copilot.Core as Core
 import Copilot.Language.Prelude
 import Copilot.Language.Stream
 import Prelude ()
+import GHC.Stack (HasCallStack)
 
 -- | Convenient synonym for 'ifThenElse'.
-mux :: Typed a => Stream Bool -> Stream a -> Stream a -> Stream a
+mux :: (HasCallStack, Typed a) => Stream Bool -> Stream a -> Stream a -> Stream a
 mux (Const True) t _  = t
 mux (Const False) _ f = f
 mux b t f             = Op3 (Core.Mux typeOf) b t f
@@ -27,5 +28,5 @@ mux b t f             = Op3 (Core.Mux typeOf) b t f
 -- Produce a stream that, at any point in time, if the value of the first
 -- stream at that point is true, contains the value in the second stream at
 -- that time, otherwise it contains the value in the third stream.
-ifThenElse :: Typed a => Stream Bool -> Stream a -> Stream a -> Stream a
+ifThenElse :: (HasCallStack, Typed a) => Stream Bool -> Stream a -> Stream a -> Stream a
 ifThenElse = mux

--- a/copilot-language/src/Copilot/Language/Operators/Ord.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Ord.hs
@@ -15,13 +15,14 @@ import qualified Copilot.Core as Core
 import Copilot.Language.Prelude
 import Copilot.Language.Stream
 import qualified Prelude as P
+import GHC.Stack (HasCallStack)
 
 -- | Compare two streams point-wise for order.
 --
 -- The output stream contains the value True at a point in time if the
 -- element in the first stream is smaller or equal than the element in
 -- the second stream at that point in time, and False otherwise.
-(<=) :: (P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
+(<=) :: (HasCallStack, P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) <= (Const y) = Const (x P.<= y)
 x <= y                 = Op2 (Core.Le typeOf) x y
 
@@ -30,7 +31,7 @@ x <= y                 = Op2 (Core.Le typeOf) x y
 -- The output stream contains the value True at a point in time if the
 -- element in the first stream is greater or equal than the element in
 -- the second stream at that point in time, and False otherwise.
-(>=) :: (P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
+(>=) :: (HasCallStack, P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) >= (Const y) = Const (x P.>= y)
 x >= y                 = Op2 (Core.Ge typeOf) x y
 
@@ -39,7 +40,7 @@ x >= y                 = Op2 (Core.Ge typeOf) x y
 -- The output stream contains the value True at a point in time if the
 -- element in the first stream is smaller than the element in the second stream
 -- at that point in time, and False otherwise.
-(<) :: (P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
+(<) :: (HasCallStack, P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) < (Const y) = Const (x P.< y)
 x < y                 = Op2 (Core.Lt typeOf) x y
 
@@ -48,6 +49,6 @@ x < y                 = Op2 (Core.Lt typeOf) x y
 -- The output stream contains the value True at a point in time if the element
 -- in the first stream is greater than the element in the second stream at that
 -- point in time, and False otherwise.
-(>) :: (P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
+(>) :: (HasCallStack, P.Ord a, Typed a) => Stream a -> Stream a -> Stream Bool
 (Const x) > (Const y) = Const (x P.> y)
 x > y                 = Op2 (Core.Gt typeOf) x y

--- a/copilot-language/src/Copilot/Language/Operators/Propositional.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Propositional.hs
@@ -16,11 +16,12 @@ import Copilot.Language.Spec (Prop (..))
 import qualified Copilot.Language.Operators.Boolean as B
 
 import Copilot.Theorem
+import GHC.Stack (HasCallStack)
 
 -- | A proposition that can be negated.
 class Negatable a b where
   -- | Negate a proposition.
-  not :: a -> b
+  not :: HasCallStack => a -> b
 
 -- | Negation of an existentially quantified proposition.
 instance Negatable (Prop Existential) (Prop Universal) where

--- a/copilot-language/src/Copilot/Language/Operators/Struct.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Struct.hs
@@ -10,6 +10,7 @@ import Copilot.Core.Operators
 import Copilot.Language.Stream  (Stream (..))
 
 import GHC.TypeLits             (KnownSymbol)
+import GHC.Stack (HasCallStack)
 
 -- | Create a stream that carries a field of a struct in another stream.
 --
@@ -18,6 +19,6 @@ import GHC.TypeLits             (KnownSymbol)
 -- of type @Word8@, and @s@ is a stream of type @Stream T@, then @s # t2@ has
 -- type @Stream Word8@ and contains the values of the @t2@ field of the structs
 -- in @s@ at any point in time.
-(#) :: (KnownSymbol s, Typed t, Typed a, Struct a)
+(#) :: (HasCallStack, KnownSymbol s, Typed t, Typed a, Struct a)
       => Stream a -> (a -> Field s t) -> Stream t
 (#) s f = Op1 (GetField typeOf typeOf f) s

--- a/copilot-language/src/Copilot/Language/Operators/Temporal.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Temporal.hs
@@ -12,6 +12,7 @@ import Copilot.Core (Typed)
 import Copilot.Language.Prelude
 import Copilot.Language.Stream
 import Prelude ()
+import GHC.Stack (HasCallStack)
 
 infixr 1 ++
 
@@ -23,7 +24,7 @@ infixr 1 ++
 -- Prepending elements to a stream may increase the memory requirements of the
 -- generated programs (which now must hold the same number of elements in
 -- memory for future processing).
-(++) :: Typed a => [a] -> Stream a -> Stream a
+(++) :: (HasCallStack, Typed a) => [a] -> Stream a -> Stream a
 (++) = (`Append` Nothing)
 
 -- | Drop a number of samples from a stream.
@@ -32,7 +33,7 @@ infixr 1 ++
 -- elements. For most kinds of streams, you cannot drop elements without
 -- prepending an equal or greater number of elements to them first, as it
 -- could result in undefined samples.
-drop :: Typed a => Int -> Stream a -> Stream a
+drop :: (HasCallStack, Typed a) => Int -> Stream a -> Stream a
 drop 0 s             = s
 drop _ ( Const j )   = Const j
 drop i ( Drop  j s ) = Drop (fromIntegral i + j) s

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -207,7 +207,7 @@ mkExpr refMkId refStreams refMap = go
 -- expression.
 {-# INLINE mkStream #-}
 mkStream
-  :: Typed a
+  :: (HasCallStack, Typed a)
   => IORef Int
   -> IORef (Map Core.Id)
   -> IORef [Core.Stream]
@@ -245,7 +245,8 @@ mkStream refMkId refStreams refMap e0 = do
         { Core.streamId         = id
         , Core.streamBuffer     = buf
         , Core.streamExpr       = w
-        , Core.streamExprType   = typeOf }
+        , Core.streamExprType   = typeOf
+        , Core.streamCallStack  = callStack }
     return id
 
 -- | Create a fresh, unused 'Id'.

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -81,13 +81,14 @@ mkTrigger
   -> IORef [Core.Stream]
   -> Trigger
   -> IO Core.Trigger
-mkTrigger refMkId refStreams refMap (Trigger name guard args) = do
+mkTrigger refMkId refStreams refMap (Trigger name guard args callStack) = do
   w1 <- mkExpr refMkId refStreams refMap guard
   args' <- mapM mkTriggerArg args
   return Core.Trigger
     { Core.triggerName  = name
     , Core.triggerGuard = w1
-    , Core.triggerArgs  = args' }
+    , Core.triggerArgs  = args'
+    , Core.triggerCallstack = callStack }
 
   where
 

--- a/copilot-language/src/Copilot/Language/Spec.hs
+++ b/copilot-language/src/Copilot/Language/Spec.hs
@@ -40,6 +40,7 @@ import qualified Copilot.Core as Core
 import Copilot.Language.Stream
 
 import Copilot.Theorem.Prove
+import GHC.Stack (HasCallStack, CallStack, callStack)
 
 -- | A specification is a list of declarations of triggers, observers,
 -- properties and theorems.
@@ -137,16 +138,17 @@ observer name e = tell [ObserverItem $ Observer name e]
 -- | A trigger, representing a function we execute when a boolean stream becomes
 -- true at a sample.
 data Trigger where
-  Trigger :: Core.Name -> Stream Bool -> [Arg] -> Trigger
+  Trigger :: Core.Name -> Stream Bool -> [Arg] -> CallStack -> Trigger
 
 -- | Define a new trigger as part of a specification. A trigger declares which
 -- external function, or handler, will be called when a guard defined by a
 -- boolean stream becomes true.
-trigger :: String       -- ^ Name of the handler to be called.
+trigger :: HasCallStack
+        => String       -- ^ Name of the handler to be called.
         -> Stream Bool  -- ^ The stream used as the guard for the trigger.
         -> [Arg]        -- ^ List of arguments to the handler.
         -> Spec
-trigger name e args = tell [TriggerItem $ Trigger name e args]
+trigger name e args = tell [TriggerItem $ Trigger name e args callStack]
 
 -- | A property, representing a boolean stream that is existentially or
 -- universally quantified over time.

--- a/copilot-language/src/Copilot/Language/Spec.hs
+++ b/copilot-language/src/Copilot/Language/Spec.hs
@@ -153,7 +153,7 @@ trigger name e args = tell [TriggerItem $ Trigger name e args callStack]
 -- | A property, representing a boolean stream that is existentially or
 -- universally quantified over time.
 data Property where
-  Property :: String -> Stream Bool -> Property
+  Property :: String -> Stream Bool -> CallStack -> Property
 
 -- | A proposition, representing the quantification of a boolean streams over
 -- time.
@@ -179,16 +179,16 @@ extractProp (Exists p) = p
 --
 -- This function returns, in the monadic context, a reference to the
 -- proposition.
-prop :: String -> Prop a -> Writer [SpecItem] (PropRef a)
-prop name e = tell [PropertyItem $ Property name (extractProp e)]
+prop :: HasCallStack => String -> Prop a -> Writer [SpecItem] (PropRef a)
+prop name e = tell [PropertyItem $ Property name (extractProp e) callStack]
   >> return (PropRef name)
 
 -- | A theorem, or proposition together with a proof.
 --
 -- This function returns, in the monadic context, a reference to the
 -- proposition.
-theorem :: String -> Prop a -> Proof a -> Writer [SpecItem] (PropRef a)
-theorem name e (Proof p) = tell [TheoremItem (Property name (extractProp e), p)]
+theorem :: HasCallStack => String -> Prop a -> Proof a -> Writer [SpecItem] (PropRef a)
+theorem name e (Proof p) = tell [TheoremItem (Property name (extractProp e) callStack, p)]
   >> return (PropRef name)
 
 -- | Construct a function argument from a stream.

--- a/copilot-language/src/Copilot/Language/Stream.hs
+++ b/copilot-language/src/Copilot/Language/Stream.hs
@@ -20,7 +20,7 @@ import qualified Copilot.Core as Core
 import Copilot.Language.Error
 import Copilot.Language.Prelude
 import qualified Prelude as P
-
+import GHC.Stack (HasCallStack)
 -- | A stream in Copilot is an infinite succession of values of the same type.
 --
 -- Streams can be built using simple primities (e.g., 'Const'), by applying
@@ -29,28 +29,28 @@ import qualified Prelude as P
 -- 'Op2', 'Op3').
 
 data Stream :: * -> * where
-  Append      :: Typed a
+  Append      :: (HasCallStack, Typed a)
               => [a] -> Maybe (Stream Bool) -> Stream a -> Stream a
-  Const       :: Typed a => a -> Stream a
-  Drop        :: Typed a
+  Const       :: (HasCallStack, Typed a) => a -> Stream a
+  Drop        :: (HasCallStack, Typed a)
               => Int -> Stream a -> Stream a
-  Extern      :: Typed a
+  Extern      :: (HasCallStack, Typed a)
               => String -> Maybe [a] -> Stream a
-  Local       :: (Typed a, Typed b)
+  Local       :: (HasCallStack, Typed a, Typed b)
               => Stream a -> (Stream a -> Stream b) -> Stream b
-  Var         :: Typed a
+  Var         :: (HasCallStack, Typed a)
               => String -> Stream a
-  Op1         :: (Typed a, Typed b)
+  Op1         :: (HasCallStack, Typed a, Typed b)
               => Core.Op1 a b -> Stream a -> Stream b
-  Op2         :: (Typed a, Typed b, Typed c)
+  Op2         :: (HasCallStack, Typed a, Typed b, Typed c)
               => Core.Op2 a b c -> Stream a -> Stream b -> Stream c
-  Op3         :: (Typed a, Typed b, Typed c, Typed d)
+  Op3         :: (HasCallStack, Typed a, Typed b, Typed c, Typed d)
               => Core.Op3 a b c d -> Stream a -> Stream b -> Stream c -> Stream d
-  Label       :: Typed a => String -> Stream a -> Stream a
+  Label       :: (HasCallStack, Typed a) => String -> Stream a -> Stream a
 
 -- | Wrapper to use 'Stream's as arguments to triggers.
 data Arg where
-  Arg :: Typed a => Stream a -> Arg
+  Arg :: (HasCallStack, Typed a) => Stream a -> Arg
 
 -- | Dummy instance in order to make 'Stream' an instance of 'Num'.
 instance Show (Stream a) where

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -111,7 +111,7 @@ prove solver spec = do
     Z3 -> WC.extendConfig WS.z3Options (WI.getConfiguration sym)
 
   -- Compute the maximum amount of delay for any stream in this spec
-  let bufLen (CS.Stream _ buf _ _) = genericLength buf
+  let bufLen (CS.Stream _ buf _ _ _) = genericLength buf
       maxBufLen = maximum (0 : (bufLen <$> CS.specStreams spec))
 
   -- This process performs k-induction where we use @k = maxBufLen@.
@@ -352,7 +352,7 @@ computeAssumptions ::
 computeAssumptions sym properties spec =
     concat <$> forM specPropertyExprs computeAssumption
   where
-    bufLen (CS.Stream _ buf _ _) = genericLength buf
+    bufLen (CS.Stream _ buf _ _ _) = genericLength buf
     maxBufLen = maximum (0 : (bufLen <$> CS.specStreams spec))
 
     -- Retrieve the boolean-values Copilot expressions corresponding to the


### PR DESCRIPTION
These changes add `HasCallStack` constraints to Copilot Language constructors, capturing callstack information within the Copilot Core data types that are translated from the Language representation. This allows for traceability from a Copilot Core representation back to the initial Copilot Language representation created by the user.