### PR TITLE
`copilot-language`: Remove oudated mention of pretty-printer. Refs #428.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2023-04-17
+        * Remove outdated comment about pretty-printer. (#428)
+
 2023-03-07
         * Version bump (3.14). (#422)
         * Remove function Copilot.Language.prettyPrint. (#412)

--- a/copilot-language/src/Copilot/Language.hs
+++ b/copilot-language/src/Copilot/Language.hs
@@ -3,8 +3,7 @@
 -- | Main Copilot language export file.
 --
 -- This is mainly a meta-module that re-exports most definitions in this
--- library. It also provides a default pretty printer that prints a
--- specification to stdout.
+-- library.
 
 {-# LANGUAGE Safe #-}
 


### PR DESCRIPTION
Remove a mention of the pretty-printer from the documentation of module `Copilot.Language`, since it is no longer exported by that module, as prescribed in the solution proposed for #428.