### PR TITLE
`copilot-language`: Move `Copilot.Language.Stream.Arg` to `Copilot.Language.Spec`. Refs #446.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2023-07-07
+        * Move Copilot.Language.Stream.Arg to Copilot.Language.Spec. (#446)
+
 2023-05-07
         * Version bump (3.15). (#438)
         * Remove outdated comment about pretty-printer. (#428)

--- a/copilot-language/src/Copilot/Language/Analyze.hs
+++ b/copilot-language/src/Copilot/Language/Analyze.hs
@@ -14,7 +14,7 @@ module Copilot.Language.Analyze
 
 import Copilot.Core (DropIdx)
 import qualified Copilot.Core as C
-import Copilot.Language.Stream (Stream (..), Arg (..))
+import Copilot.Language.Stream (Stream (..))
 import Copilot.Language.Spec
 import Copilot.Language.Error (badUsage)
 

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -17,7 +17,7 @@ import Copilot.Core (Typed, Id, typeOf)
 import Copilot.Language.Analyze (analyze)
 import Copilot.Language.Error   (impossible)
 import Copilot.Language.Spec
-import Copilot.Language.Stream (Stream (..), Arg (..))
+import Copilot.Language.Stream (Stream (..))
 
 import Copilot.Theorem.Prove
 

--- a/copilot-language/src/Copilot/Language/Spec.hs
+++ b/copilot-language/src/Copilot/Language/Spec.hs
@@ -22,6 +22,7 @@ module Copilot.Language.Spec
   , Trigger (..)
   , trigger, triggers
   , arg
+  , Arg(..)
   , Property (..)
   , Prop (..)
   , prop, properties
@@ -198,3 +199,7 @@ theorem name e (Proof p) = tell [TheoremItem (Property name (extractProp e), p)]
 -- the current samples of the given streams.
 arg :: Typed a => Stream a -> Arg
 arg = Arg
+
+-- | Wrapper to use 'Stream's as arguments to triggers.
+data Arg where
+  Arg :: Typed a => Stream a -> Arg

--- a/copilot-language/src/Copilot/Language/Stream.hs
+++ b/copilot-language/src/Copilot/Language/Stream.hs
@@ -9,7 +9,6 @@
 
 module Copilot.Language.Stream
   ( Stream (..)
-  , Arg (..)
   , Copilot.Language.Stream.ceiling
   , Copilot.Language.Stream.floor
   , Copilot.Language.Stream.atan2
@@ -47,10 +46,6 @@ data Stream :: * -> * where
   Op3         :: (Typed a, Typed b, Typed c, Typed d)
               => Core.Op3 a b c d -> Stream a -> Stream b -> Stream c -> Stream d
   Label       :: Typed a => String -> Stream a -> Stream a
-
--- | Wrapper to use 'Stream's as arguments to triggers.
-data Arg where
-  Arg :: Typed a => Stream a -> Arg
 
 -- | Dummy instance in order to make 'Stream' an instance of 'Num'.
 instance Show (Stream a) where


### PR DESCRIPTION
Move `Copilot.Language.Stream.Arg` to `Copilot.Language.Spec` and adjusts imports, as prescribed in the solution proposed for #446. 