### PR TITLE
`copilot-libraries`: Fix semantics of `since` in `Copilot.Library.PTLTL`. Refs #443.

### DIFF
--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2023-07-27
+        * Fix semantics of since in Copilot.Library.PTLTL. (#443)
+
 2023-07-07
         * Version bump (3.16). (#448)
 

--- a/copilot-libraries/src/Copilot/Library/PTLTL.hs
+++ b/copilot-libraries/src/Copilot/Library/PTLTL.hs
@@ -39,8 +39,6 @@ eventuallyPrev s = s || tmp
   where
     tmp = [ False ] ++ s || tmp
 
--- | Once @s2@ holds, in the following state (period), does @s1@ continuously hold?
-since ::  Stream Bool -> Stream Bool -> Stream Bool
-since s1 s2 = alwaysBeen ( tmp ==> s1 )
-    where
-      tmp = eventuallyPrev $ [ False ] ++ s2
+-- | Is there a time when @s2@ holds and after which @s1@ continuously holds?
+since :: Stream Bool -> Stream Bool -> Stream Bool
+since s1 s2 = eventuallyPrev (s2 ==> (alwaysBeen s1))


### PR DESCRIPTION
Fix the semantics of `since` to be true if there exists any point at which `s2` holds and after which `s1` continuously holds, as prescribed in the solution proposed for https://github.com/Copilot-Language/copilot/issues/443.