### PR TITLE
`copilot-libraries`: Don't generate unused locals in majority vote implementation. Refs #408.

### DIFF
--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,5 +1,7 @@
-2023-07-27
+2023-08-08
         * Fix semantics of since in Copilot.Library.PTLTL. (#443)
+        * Prevent the majority function from generating unused local variables.
+          (#408)
 
 2023-07-07
         * Version bump (3.16). (#448)

--- a/copilot-libraries/src/Copilot/Library/Voting.hs
+++ b/copilot-libraries/src/Copilot/Library/Voting.hs
@@ -56,7 +56,17 @@ majority' (x:xs) can cnt =
   where
   inZero zero    = local (if zero then x else can) inCan
     where
-    inCan can'   = local (if zero || x == can then cnt+1 else cnt-1) inCnt
+    inCan can' =
+        -- We include a special case for when `xs` is empty that immediately
+        -- returns `can'`. We could omit this special case without changing the
+        -- final result, but this has the downside that `local` would bind a
+        -- local variable that would go unused in `inCnt`. (Note that `inCnt`
+        -- recursively invokes `majority'`, which doesn't use its last argument
+        -- if the list of vote streams is empty.) These unused local variables
+        -- would result in C code that triggers compiler warnings.
+        case xs of
+          [] -> can'
+          _  -> local (if zero || x == can then cnt+1 else cnt-1) inCnt
       where
       inCnt cnt' = majority' xs can' cnt'
 


### PR DESCRIPTION
The `Copilot.Library.Voting.majority'` function, used as part of an implementation of a majority-vote algorithm, would generate unused local variables if given a list with only one vote stream. This happens quite a lot, as `majority'` is a recursive function that decreases the size of the list at every recursive call. Moreover, these unused local variables will cause the C code generated by Copilot to trigger warnings when compiled.

This fixes the issue by adding a special case in `majority'` for when the input list only has one vote stream, which avoids needlessly binding a local variable.