### PR TITLE
`copilot`: Fix typo. Refs #459.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2023-11-03
+        * Fix typo in README. (#459)
+
 2023-09-07
         * Version bump (3.16.1). (#455)
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -222,7 +222,7 @@ does not constitute any form of endorsement._
 - [sketch-frp-copilot](https://hackage.haskell.org/package/sketch-frp-copilot)
   extends Copilot with an FRP-like interface.
 
-- [zephir-copilot](https://hackage.haskell.org/package/zephyr-copilot)
+- [zephyr-copilot](https://hackage.haskell.org/package/zephyr-copilot)
   facilitates building copilot applications that run on boards supported by the
   Zephyr project.
 


### PR DESCRIPTION
Fix spelling of Zephyr in the README as described in the solution proposed for #459.