### PR TITLE
`copilot-theorem`: Relax version constraint on `what4`. Refs #461.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2023-11-03
+        * Relax version constraint on what4. (#461)
+
 2023-09-07
         * Version bump (3.16.1). (#455)
 

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -61,7 +61,7 @@ library
                           , random                >= 1.1 && < 1.3
                           , transformers          >= 0.5 && < 0.7
                           , xml                   >= 1.3 && < 1.4
-                          , what4                 >= 1.3 && < 1.5
+                          , what4                 >= 1.3 && < 1.6
 
                           , copilot-core          >= 3.16.1 && < 3.17
                           , copilot-prettyprinter >= 3.16.1 && < 3.17


### PR DESCRIPTION
Extend range of versions of `what4` supported, as prescribed in the solution proposed for #461.