### PR TITLE
`copilot-c99`: Change return type of `main` generated for tests. Refs #468.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2023-12-14
+        * Change return type of main generated for tests. (#468)
+
 2023-11-07
         * Version bump (3.17). (#466)
         * Replace uses of deprecated functions. (#457)

--- a/copilot-c99/tests/Test/Copilot/Compile/C99.hs
+++ b/copilot-c99/tests/Test/Copilot/Compile/C99.hs
@@ -157,7 +157,7 @@ testRun = ioProperty $ do
           , "void nop () {"
           , "}"
           , ""
-          , "void main () {"
+          , "int main () {"
           , "  step();"
           , "}"
           ]


### PR DESCRIPTION
Modify the tests for `copilot-c99` so that the `main` has type `int`, making it implicitly also return `0`, as prescribed in the solution proposed for #468.

