### PR TITLE
`copilot-language`: Add type annotation to help type inference engine. Refs #469.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2023-12-17
+        * Add type annotation to help type inference engine. (#469)
+
 2023-11-07
         * Version bump (3.17). (#466)
 

--- a/copilot-language/tests/Test/Copilot/Language/Reify.hs
+++ b/copilot-language/tests/Test/Copilot/Language/Reify.hs
@@ -31,7 +31,7 @@ import qualified Copilot.Language.Operators.Integral as Copilot
 import qualified Copilot.Language.Operators.Mux      as Copilot
 import qualified Copilot.Language.Operators.Ord      as Copilot
 import           Copilot.Language.Reify              (reify)
-import           Copilot.Language.Spec               (observer)
+import           Copilot.Language.Spec               (Spec, observer)
 import           Copilot.Language.Stream             (Stream)
 import qualified Copilot.Language.Stream             as Copilot
 
@@ -732,7 +732,11 @@ semanticsShowK steps (SemanticsP (expr, exprList)) =
 checkSemanticsP :: Int -> [a] -> SemanticsP -> IO Bool
 checkSemanticsP steps _streams (SemanticsP (expr, exprList)) = do
     -- Spec with just one observer of one expression.
-    let spec = observer testObserverName expr
+    --
+    -- Because SemanticsP is an existential type, we need to help GHC figure
+    -- out the type of spec.
+    let spec :: Spec
+        spec = observer testObserverName expr
 
     -- Reified stream (low-level)
     llSpec <- reify spec


### PR DESCRIPTION
Add type signature to an internal definition that uses values of an existential type, making the code for the tests compile with newer versions of GHC (>= 9.4), as required by #469 .