### PR TITLE
`copilot-c99`: Print constants in tests using portable suffixes. Refs #471.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
-2023-12-14
+2023-12-17
         * Change return type of main generated for tests. (#468)
+        * Print constants in tests using portable suffixes. (#471).
 
 2023-11-07
         * Version bump (3.17). (#466)

--- a/copilot-c99/tests/Test/Copilot/Compile/C99.hs
+++ b/copilot-c99/tests/Test/Copilot/Compile/C99.hs
@@ -886,28 +886,52 @@ class CShow s where
   cshow :: s -> String
 
 instance CShow Int8 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "INT8_C(" ++ show x ++ ")"
 
 instance CShow Int16 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "INT16_C(" ++ show x ++ ")"
 
 instance CShow Int32 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "INT32_C(" ++ show x ++ ")"
 
 instance CShow Int64 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "INT64_C(" ++ show x ++ ")"
 
 instance CShow Word8 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "UINT8_C(" ++ show x ++ ")"
 
 instance CShow Word16 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "UINT16_C(" ++ show x ++ ")"
 
 instance CShow Word32 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "UINT32_C(" ++ show x ++ ")"
 
 instance CShow Word64 where
-  cshow = show
+  -- Use a macro to ensure that any necessary suffixes are added to the number.
+  -- We choose this macro instead of specifically adding a suffix for reasons
+  -- of portability.
+  cshow x = "UINT64_C(" ++ show x ++ ")"
 
 instance CShow Float where
   cshow = show


### PR DESCRIPTION
This commit adjusts the tests for the `copilot-c99` library to use a portable way of printing constants in the C code generated by the tests, as prescribed in the solution proposed for #471.