### PR TITLE
`copilot-c99`: compliance with MISRA C 2012. Refs #472.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# dist should be at least focal because we need cppcheck >= 1.88.
+dist: focal
+
 # NB: don't set `language: haskell` here
 
 # The following enables several GHC versions to be tested; often it's enough to
@@ -16,9 +19,9 @@ before_install:
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
 
-  # We install z3 only for the tests, since it is not needed for normal
-  # compilation.
-  - if [ "${GHCVER}" == "8.10.4" ]; then travis_retry sudo apt-get install --yes z3; fi
+  # We install z3 and cppcheck only for the tests, since they are not needed
+  # for normal compilation.
+  - if [ "${GHCVER}" == "8.10.4" ]; then travis_retry sudo apt-get install --yes z3 cppcheck; fi
 
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
   - cabal --version
@@ -27,7 +30,10 @@ before_install:
   - git submodule update --remote
 
 script:
-  - travis_wait 30 cabal v2-install --lib copilot
+  # We explicitly install all libraries so that they are exposed and we can use
+  # them for tests (e.g., with runhaskell). There is no harm in doing this
+  # instead of installing just copilot.
+  - travis_wait 30 cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language copilot-libraries copilot-theorem copilot-interpreter copilot-prettyprinter
 
   # Run tests only on GHC 8.10.4
   #
@@ -37,3 +43,8 @@ script:
   # conditional installation, and keep GHC version numbers in both places in
   # sync.
   - if [ "${GHCVER}" == "8.10.4" ]; then cabal v2-test -j1 copilot-core copilot-language copilot-interpreter copilot-c99 copilot-theorem copilot-libraries; fi
+
+  # Check that the code produced by Copilot complies with MISRA C 2012. We
+  # explicitly make cppcheck produce a non-zero exit code on non-compliance
+  # with the standard to make the CI build fail.
+  - if [ "${GHCVER}" == "8.10.4" ]; then runhaskell copilot/examples/Heater.hs; cppcheck --force --addon=misra.py --suppress=misra-c2012-14.4 --error-exitcode=2 heater.c; fi

--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,7 +1,8 @@
-2023-12-19
+2024-01-06
         * Change return type of main generated for tests. (#468)
         * Print constants in tests using portable suffixes. (#471).
         * Pass output arrays as arguments to trigger argument functions. (#431)
+        * Compliance with MISRA C 2023 / MISRA C 2012. (#472)
 
 2023-11-07
         * Version bump (3.17). (#466)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -47,7 +47,7 @@ library
 
                           , copilot-core        >= 3.17  && < 3.18
                           , language-c99        >= 0.2.0 && < 0.3
-                          , language-c99-simple >= 0.2.2 && < 0.3
+                          , language-c99-simple >= 0.3   && < 0.4
 
   exposed-modules         : Copilot.Compile.C99
 

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -100,7 +100,8 @@ mkIndexDecln sId = C.VarDecln (Just C.Static) cTy name initVal
 
 -- | Define an accessor functions for the ring buffer associated with a stream.
 mkAccessDecln :: Id -> Type a -> [a] -> C.FunDef
-mkAccessDecln sId ty xs = C.FunDef cTy name params [] [C.Return (Just expr)]
+mkAccessDecln sId ty xs =
+    C.FunDef Nothing cTy name params [] [C.Return (Just expr)]
   where
     cTy        = C.decay $ transType ty
     name       = streamAccessorName sId
@@ -113,7 +114,8 @@ mkAccessDecln sId ty xs = C.FunDef cTy name params [] [C.Return (Just expr)]
 
 -- | Write a generator function for a stream.
 mkGenFun :: String -> Expr a -> Type a -> C.FunDef
-mkGenFun name expr ty = C.FunDef cTy name [] cVars [C.Return $ Just cExpr]
+mkGenFun name expr ty =
+    C.FunDef Nothing cTy name [] cVars [C.Return $ Just cExpr]
   where
     cTy            = C.decay $ transType ty
     (cExpr, cVars) = runState (transExpr expr) mempty
@@ -121,7 +123,7 @@ mkGenFun name expr ty = C.FunDef cTy name [] cVars [C.Return $ Just cExpr]
 -- | Write a generator function for a stream that returns an array.
 mkGenFunArray :: String -> String -> Expr a -> Type a -> C.FunDef
 mkGenFunArray name nameArg expr ty@(Array _) =
-    C.FunDef funType name [ outputParam ] varDecls stmts
+    C.FunDef Nothing funType name [ outputParam ] varDecls stmts
   where
     funType = C.TypeSpec C.Void
 
@@ -145,7 +147,7 @@ mkGenFunArray _name _nameArg _expr _ty =
 -- | Define the step function that updates all streams.
 mkStep :: CSettings -> [Stream] -> [Trigger] -> [External] -> C.FunDef
 mkStep cSettings streams triggers exts =
-    C.FunDef void (cSettingsStepFunctionName cSettings) [] declns stmts
+    C.FunDef Nothing void (cSettingsStepFunctionName cSettings) [] declns stmts
   where
     void = C.TypeSpec C.Void
 

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -101,8 +101,9 @@ mkIndexDecln sId = C.VarDecln (Just C.Static) cTy name initVal
 -- | Define an accessor functions for the ring buffer associated with a stream.
 mkAccessDecln :: Id -> Type a -> [a] -> C.FunDef
 mkAccessDecln sId ty xs =
-    C.FunDef Nothing cTy name params [] [C.Return (Just expr)]
+    C.FunDef static cTy name params [] [C.Return (Just expr)]
   where
+    static     = Just C.Static
     cTy        = C.decay $ transType ty
     name       = streamAccessorName sId
     buffLength = C.LitInt $ fromIntegral $ length xs
@@ -115,16 +116,18 @@ mkAccessDecln sId ty xs =
 -- | Write a generator function for a stream.
 mkGenFun :: String -> Expr a -> Type a -> C.FunDef
 mkGenFun name expr ty =
-    C.FunDef Nothing cTy name [] cVars [C.Return $ Just cExpr]
+    C.FunDef static cTy name [] cVars [C.Return $ Just cExpr]
   where
+    static         = Just C.Static
     cTy            = C.decay $ transType ty
     (cExpr, cVars) = runState (transExpr expr) mempty
 
 -- | Write a generator function for a stream that returns an array.
 mkGenFunArray :: String -> String -> Expr a -> Type a -> C.FunDef
 mkGenFunArray name nameArg expr ty@(Array _) =
-    C.FunDef Nothing funType name [ outputParam ] varDecls stmts
+    C.FunDef static funType name [ outputParam ] varDecls stmts
   where
+    static  = Just C.Static
     funType = C.TypeSpec C.Void
 
     -- The output value is an array

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,7 +1,8 @@
-2023-12-27
+2024-01-06
         * Enable tests for copilot-theorem in CI script. (#474)
         * Enable tests for copilot-libraries in CI script. (#475)
         * Replace uses of forall with forAll. (#470)
+        * Update CI job to check for MISRA compliance with cppcheck. (#472)
 
 2023-11-07
         * Version bump (3.17). (#466)


### PR DESCRIPTION
Adjust C99 backend to comply with all MISRA C 2012 rules (up to date with MISRA C 2023), as prescribed in the solution proposed for #472.

This commit does not modify the README just yet, contrary to the suggested solution to #472. This is intentional: there is no suitable place to indicate information about compliance, or lack thereof, with MISRA C. I suggest we open a separate issue extending the README and showing the features of Copilot more prominently. That will create the space to talk about MISRA compliance and also list the advisory we do not currently comply with.