### PR TITLE
`copilot`: Relax version constraint on `optparse-applicative`. Refs #488.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,8 +1,9 @@
-2024-01-06
+2024-01-07
         * Enable tests for copilot-theorem in CI script. (#474)
         * Enable tests for copilot-libraries in CI script. (#475)
         * Replace uses of forall with forAll. (#470)
         * Update CI job to check for MISRA compliance with cppcheck. (#472)
+        * Relax version constraint on optparse-applicative. (#488)
 
 2023-11-07
         * Version bump (3.17). (#466)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -48,7 +48,7 @@ library
       -fno-warn-orphans
     build-depends:
                        base                  >= 4.9  && < 5
-                     , optparse-applicative  >= 0.14 && < 0.18
+                     , optparse-applicative  >= 0.14 && < 0.19
                      , directory             >= 1.3  && < 1.4
                      , filepath              >= 1.4  && < 1.5
 


### PR DESCRIPTION
Extend range of versions of `optparse-applicative` supported, as prescribed in the solution proposed for #488.