### PR TITLE
`copilot-theorem`: Adjust to work with GHC 9.6. Refs #491.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,4 +1,7 @@
 2024-01-07
+        * Adjust to work with GHC 9.6. (#491)
+
+2024-01-07
         * Version bump (3.18). (#487)
         * Introduce testing infrastructure for Copilot.Theorem.What4. (#474)
         * Replace uses of forall with forAll. (#470)

--- a/copilot-theorem/src/Copilot/Theorem/IL/Translate.hs
+++ b/copilot-theorem/src/Copilot/Theorem/IL/Translate.hs
@@ -14,6 +14,7 @@ import qualified Copilot.Core as C
 
 import qualified Data.Map.Strict as Map
 
+import Control.Monad       (forM, liftM2, when)
 import Control.Monad.State
 
 import Data.Char

--- a/copilot-theorem/src/Copilot/Theorem/Misc/Utils.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Misc/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 
 -- | Utility / auxiliary functions.
 module Copilot.Theorem.Misc.Utils

--- a/copilot-theorem/src/Copilot/Theorem/Prove.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Prove.hs
@@ -22,6 +22,7 @@ import qualified Copilot.Core as Core
 
 import Data.List (intercalate)
 import Control.Applicative (liftA2)
+import Control.Monad        (ap, liftM)
 import Control.Monad.Writer
 
 -- | Output produced by a prover, containing the 'Status' of the proof and

--- a/copilot-theorem/src/Copilot/Theorem/TransSys/Translate.hs
+++ b/copilot-theorem/src/Copilot/Theorem/TransSys/Translate.hs
@@ -47,6 +47,7 @@ import Copilot.Theorem.TransSys.Spec
 import Copilot.Theorem.TransSys.Cast
 import Copilot.Theorem.Misc.Utils
 
+import Control.Monad            (liftM, liftM2, unless)
 import Control.Monad.State.Lazy
 
 import Data.Char (isNumber)

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -57,6 +57,7 @@ import qualified What4.InterpretedFloatingPoint as WFP
 import qualified What4.Solver                   as WS
 import qualified What4.Solver.DReal             as WS
 
+import Control.Monad (forM)
 import Control.Monad.State
 import qualified Data.BitVector.Sized as BV
 import Data.Foldable (foldrM)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,4 +1,7 @@
 2024-01-07
+        * Update README to reflect support for GHC 9.6. (#491)
+
+2024-01-07
         * Version bump (3.18). (#487)
         * Enable tests for copilot-theorem in CI script. (#474)
         * Enable tests for copilot-libraries in CI script. (#475)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -81,7 +81,7 @@ ghci> ghci> Leaving GHCi.
 On other Linux distributions or older Debian-based distributions, to use
 Copilot you must install a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.4 as of this writing). You can install the toolchain using
+(9.6 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/) or, if you are on Debian/Ubuntu,
 directly with `apt-get`:
 
@@ -111,7 +111,7 @@ ghci> ghci> Leaving GHCi.
 
 To use Copilot you must have a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.4 as of this writing). You can install the toolchain using
+(9.6 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/), as well as with Homebrew:
 
 ```sh


### PR DESCRIPTION
Make imports from `Control.Monad` explicit as opposed to available via re-exports, and mark module that imports `System.Directory` as trustworthy, as prescribed in the solution proposed for #491.