### PR TITLE
`copilot-core`: Remove deprecated functions in `Copilot.Core.Type` and `Copilot.Core.Type.Array`. Refs #500.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,7 @@
+2024-03-07
+        * Remove deprecated functions in Copilot.Core.Type and
+          Copilot.Core.Type.Array. (#500)
+
 2024-01-07
         * Version bump (3.18.1). (#493)
 

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -30,7 +30,6 @@ module Copilot.Core.Type
     , toValues
     , Field (..)
     , typeName
-    , typename
 
     , Struct
     , fieldName
@@ -53,18 +52,11 @@ import GHC.TypeLits       (KnownNat, KnownSymbol, Symbol, natVal, sameNat,
 -- Internal imports
 import Copilot.Core.Type.Array (Array)
 
-{-# DEPRECATED typename "Use typeName instead." #-}
-
 -- | The value of that is a product or struct, defined as a constructor with
 -- several fields.
 class Struct a where
   -- | Returns the name of struct in the target language.
   typeName :: a -> String
-  typeName = typename
-
-  -- | Returns the name of struct in the target language.
-  typename :: a -> String
-  typename = typeName
 
   -- | Transforms all the struct's fields into a list of values.
   toValues :: a -> [Value a]

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -24,7 +24,6 @@ module Copilot.Core.Type
     , SimpleType (..)
 
     , typeSize
-    , tysize
     , typeLength
     , tylength
 
@@ -146,11 +145,6 @@ tylength = typeLength
 typeSize :: forall n t . KnownNat n => Type (Array n t) -> Int
 typeSize ty@(Array ty'@(Array _)) = typeLength ty * typeSize ty'
 typeSize ty@(Array _            ) = typeLength ty
-
-{-# DEPRECATED tysize "Use typeSize instead." #-}
--- | Return the total (nested) size of an array from its type
-tysize :: forall n t . KnownNat n => Type (Array n t) -> Int
-tysize = typeSize
 
 instance TestEquality Type where
   testEquality Bool   Bool   = Just DE.Refl

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -34,7 +34,6 @@ module Copilot.Core.Type
     , Struct
     , fieldName
     , accessorName
-    , accessorname
     )
   where
 
@@ -77,13 +76,6 @@ fieldName _ = symbolVal (Proxy :: Proxy s)
 accessorName :: forall a s t . (Struct a, KnownSymbol s)
              => (a -> Field s t) -> String
 accessorName _ = symbolVal (Proxy :: Proxy s)
-
-{-# DEPRECATED accessorname "Use accessorName instead." #-}
--- | Extract the name of an accessor (a function that returns a field of a
--- struct).
-accessorname :: forall a s t . (Struct a, KnownSymbol s)
-             => (a -> Field s t) -> String
-accessorname = accessorName
 
 instance (KnownSymbol s, Show t) => Show (Field s t) where
   show f@(Field v) = fieldName f ++ ":" ++ show v

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -25,7 +25,6 @@ module Copilot.Core.Type
 
     , typeSize
     , typeLength
-    , tylength
 
     , Value (..)
     , toValues
@@ -135,11 +134,6 @@ data Type :: * -> * where
 -- | Return the length of an array from its type
 typeLength :: forall n t . KnownNat n => Type (Array n t) -> Int
 typeLength _ = fromIntegral $ natVal (Proxy :: Proxy n)
-
-{-# DEPRECATED tylength "Use typeLength instead." #-}
--- | Return the length of an array from its type
-tylength :: forall n t . KnownNat n => Type (Array n t) -> Int
-tylength = typeLength
 
 -- | Return the total (nested) size of an array from its type
 typeSize :: forall n t . KnownNat n => Type (Array n t) -> Int

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -33,7 +33,6 @@ module Copilot.Core.Type
 
     , Struct
     , fieldName
-    , fieldname
     , accessorName
     , accessorname
     )
@@ -72,11 +71,6 @@ data Field (s :: Symbol) t = Field t
 -- | Extract the name of a field.
 fieldName :: forall s t . KnownSymbol s => Field s t -> String
 fieldName _ = symbolVal (Proxy :: Proxy s)
-
-{-# DEPRECATED fieldname "Use fieldName instead." #-}
--- | Extract the name of a field.
-fieldname :: forall s t . KnownSymbol s => Field s t -> String
-fieldname = fieldName
 
 -- | Extract the name of an accessor (a function that returns a field of a
 -- struct).

--- a/copilot-core/src/Copilot/Core/Type/Array.hs
+++ b/copilot-core/src/Copilot/Core/Type/Array.hs
@@ -14,7 +14,6 @@ module Copilot.Core.Type.Array
     ( Array
     , array
     , arrayElems
-    , arrayelems
     )
   where
 
@@ -43,8 +42,3 @@ array xs | datalen == typelen = Array xs
 -- | Return the elements of an array.
 arrayElems :: Array n a -> [a]
 arrayElems (Array xs) = xs
-
-{-# DEPRECATED arrayelems "Use ArrayElems instead." #-}
--- | Return the elemts of an array.
-arrayelems :: Array n a -> [a]
-arrayelems = arrayElems


### PR DESCRIPTION
Remove deprecated functions from the modules `Copilot.Core.Type` and `Copilot.Core.Type.Array`, as prescribed in the solution proposed for #500.