### PR TITLE
`copilot-theorem`: Look for `falsifiable` (not `invalid`). Refs #495.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2024-05-05
+        * Fix handling of unsatisfiable properties with Kind2. (#495)
+
 2024-03-07
         * Version bump (3.19). (#504)
 

--- a/copilot-theorem/src/Copilot/Theorem/Kind2/Output.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Kind2/Output.hs
@@ -19,9 +19,9 @@ parseOutput :: String    -- ^ Property whose validity is being checked.
 parseOutput prop xml = fromJust $ do
   root <- parseXMLDoc xml
   case findAnswer . findPropTag $ root of
-    "valid"   -> return (Output Valid   [])
-    "invalid" -> return (Output Invalid [])
-    s         -> err $ "Unrecognized status : " ++ s
+    "valid"       -> return (Output Valid   [])
+    "falsifiable" -> return (Output Invalid [])
+    s             -> err $ "Unrecognized status : " ++ s
 
   where
 


### PR DESCRIPTION
In Kind2-0.7.2, disproven properties are tagged with `falsifiable` in the XML output, but the code in `copilot-theorem`'s Kind2 backend was instead searching for a tag named `invalid`. As a result, `copilot-theorem` would error when attempting to disprove properties that are false, as it fail to parse the XML output. This fixes the issue by replacing `invalid` with `falsifiable`.

Fixes #495.