### PR TITLE
An example default implementation of the `Struct` typeclass based on `GHC.Generics`

### DIFF
--- a/copilot/examples/Structs.hs
+++ b/copilot/examples/Structs.hs
@@ -2,6 +2,7 @@
 -- nested structs) are compiled to C using copilot-c99.
 
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Main where
 
@@ -11,42 +12,31 @@ import Control.Monad (void, forM_)
 import Language.Copilot
 import Copilot.Compile.C99
 
+import GHC.Generics
+
 -- | Definition for `Volts`.
 data Volts = Volts
   { numVolts :: Field "numVolts" Word16
   , flag     :: Field "flag"     Bool
   }
+  deriving Generic
 
 -- | `Struct` instance for `Volts`.
+-- toValues is automatically implemented using Generic
+-- Also, no need to manually implement `Typed` is necessary.
 instance Struct Volts where
   typeName _ = "volts"
-  toValues volts = [ Value Word16 (numVolts volts)
-                   , Value Bool   (flag volts)
-                   ]
-
--- | `Volts` instance for `Typed`.
-instance Typed Volts where
-  typeOf = Struct (Volts (Field 0) (Field False))
 
 data Battery = Battery
   { temp  :: Field "temp"  Word16
   , volts :: Field "volts" (Array 10 Volts)
   , other :: Field "other" (Array 10 (Array 5 Word32))
   }
+  deriving Generic
 
 -- | `Battery` instance for `Struct`.
 instance Struct Battery where
   typeName _ = "battery"
-  toValues battery = [ Value typeOf (temp battery)
-                     , Value typeOf (volts battery)
-                     , Value typeOf (other battery)
-                     ]
-
--- | `Battery` instance for `Typed`. Note that `undefined` is used as an
--- argument to `Field`. This argument is never used, so `undefined` will never
--- throw an error.
-instance Typed Battery where
-  typeOf = Struct (Battery (Field 0) (Field undefined) (Field undefined))
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
I had a few conversations with @fdedden during and after ZuriHack about the possibility of adding instances of the `Struct` class for user-defined datatypes with less boilerplate, potentially using Generics.

Furthermore, the separate instances of the `Typed` class are no longer necessary if one uses an overlappable instance. (Which is fine, as a type will never be _both_ implementing `Struct` _and_ be one of the other non-struct types at the same time.)

I thought this should be possible and not terribly difficult, so as I had a little time this evening I gave it a shot.

This PR is not intended to be merged; it is only example code that should give you an idea of how GHC.Generics could be used to accomplish the desired task.
