### PR TITLE
`copilot-theorem`: Relax version constraint on what4. Refs #514.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-06
+        * What4 upper-bound dependency version bump. (#514)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
         * Fix handling of unsatisfiable properties with Kind2. (#495)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -61,7 +61,7 @@ library
                           , random                >= 1.1 && < 1.3
                           , transformers          >= 0.5 && < 0.7
                           , xml                   >= 1.3 && < 1.4
-                          , what4                 >= 1.3 && < 1.6
+                          , what4                 >= 1.3 && < 1.7
 
                           , copilot-core          >= 3.19.1 && < 3.20
                           , copilot-prettyprinter >= 3.19.1 && < 3.20


### PR DESCRIPTION
Relax version constraint on `what4` to allow installation with `what4-1.6`, as prescribed in the solution proposed for #514.