### PR TITLE
`copilot-language`: Remove deprecated function `Copilot.Language.Spec.forall`. Refs #518.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-06
+        * Remove deprecated function Copilot.Language.Spec.forall. (#518)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
 

--- a/copilot-language/src/Copilot/Language.hs
+++ b/copilot-language/src/Copilot/Language.hs
@@ -38,7 +38,7 @@ module Copilot.Language
   , prop
   , theorem
   , forAll
-  , forall, exists
+  , exists
   ) where
 
 import Data.Int hiding (Int)

--- a/copilot-language/src/Copilot/Language/Spec.hs
+++ b/copilot-language/src/Copilot/Language/Spec.hs
@@ -28,7 +28,7 @@ module Copilot.Language.Spec
   , prop, properties
   , theorem, theorems
   , forAll
-  , forall, exists
+  , exists
   , extractProp
   , Universal, Existential
   ) where
@@ -164,11 +164,6 @@ data Prop a where
 -- | Universal quantification of boolean streams over time.
 forAll :: Stream Bool -> Prop Universal
 forAll = Forall
-
-{-# DEPRECATED forall "Use forAll instead." #-}
--- | Universal quantification of boolean streams over time.
-forall :: Stream Bool -> Prop Universal
-forall = forAll
 
 -- | Existential quantification of boolean streams over time.
 exists :: Stream Bool -> Prop Existential

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-06
+        * Update README to reflect support for GHC 9.8. (#518)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -81,7 +81,7 @@ ghci> ghci> Leaving GHCi.
 On other Linux distributions or older Debian-based distributions, to use
 Copilot you must install a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.6 as of this writing). You can install the toolchain using
+(9.8 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/) or, if you are on Debian/Ubuntu,
 directly with `apt-get`:
 


### PR DESCRIPTION
Remove the deprecated function `Copilot.Language.Spec.forall` and all exports of it, as prescribed in the solution proposed for #518.