### PR TITLE
`copilot-language`: Add support for struct field updates. Refs #520.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-07
+        * Add support for struct field updates. (#520)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
 

--- a/copilot-c99/src/Copilot/Compile/C99/Expr.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Expr.hs
@@ -32,7 +32,9 @@ transExpr (Local ty1 _ name e1 e2) = do
       initExpr = Just $ C.InitExpr e1'
 
   -- Add new decl to the tail of the fun env
-  modify (++ [C.VarDecln Nothing cTy1 name initExpr])
+  modify (\(i, x, y)
+             -> (i, x ++ [C.VarDecln Nothing cTy1 name initExpr], y)
+         )
 
   transExpr e2
 
@@ -368,7 +370,7 @@ typeIsFloating _      = False
 -- | Auxiliary type used to collect all the declarations of all the variables
 -- used in a function to be generated, since variable declarations are always
 -- listed first at the top of the function body.
-type FunEnv = [C.Decln]
+type FunEnv = (Int, [C.Decln], [C.Stmt])
 
 -- | Define a C expression that calls a function with arguments.
 funCall :: C.Ident   -- ^ Function name

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-07
+        * Update Op2, Struct to support struct field updates. (#520)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
 

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -13,9 +13,10 @@ module Copilot.Core.Operators
   where
 
 -- External imports
-import Data.Bits    (Bits)
-import Data.Word    (Word32)
-import GHC.TypeLits (KnownSymbol)
+import Data.Bits     (Bits)
+import Data.Typeable (Typeable)
+import Data.Word     (Word32)
+import GHC.TypeLits  (KnownSymbol)
 
 -- Internal imports
 import Copilot.Core.Type       (Field (..), Type (..))
@@ -95,6 +96,11 @@ data Op2 a b c where
   -- Array operator.
   Index    :: Type (Array n t) -> Op2 (Array n t) Word32 t
               -- ^ Array access/projection of an array element.
+
+  -- Struct operator.
+  UpdateField :: (Typeable b, KnownSymbol s, Show b)
+              => Type a -> Type b -> (a -> Field s b) -> Op2 a b a
+              -- ^ Update a field of a struct.
 
 -- | Ternary operators.
 data Op3 a b c d where

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -34,6 +34,7 @@ module Copilot.Core.Type
     , Struct
     , fieldName
     , accessorName
+    , updateField
     )
   where
 
@@ -58,6 +59,9 @@ class Struct a where
 
   -- | Transforms all the struct's fields into a list of values.
   toValues :: a -> [Value a]
+
+  updateField :: a -> Value t -> a
+  updateField = error "Field updates not supported for this type."
 
 -- | The field of a struct, together with a representation of its type.
 data Value a =

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-07
+        * Add support for struct field updates. (#520)
+
 2024-05-07
         * Version bump (3.19.1). (#512)
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,5 +1,6 @@
-2024-07-06
+2024-07-07
         * Remove deprecated function Copilot.Language.Spec.forall. (#518)
+        * Add support for struct field updates. (#520)
 
 2024-05-07
         * Version bump (3.19.1). (#512)

--- a/copilot-language/src/Copilot/Language/Operators/Struct.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Struct.hs
@@ -1,8 +1,35 @@
 {-# LANGUAGE Safe #-}
 
 -- | Combinators to deal with streams carrying structs.
+--
+-- We support two kinds of operations on structs: reading the fields of structs
+-- and modifying the fields of structs.
+--
+-- To obtain the values of field @x@ of a struct @s@, you can just write:
+--
+-- @
+-- expr = s # x
+-- @
+--
+-- If you want to update it, use instead a double hash to refer to the field.
+-- You can either update the field:
+--
+-- @
+-- expr = s ## x =: 75
+-- @
+--
+-- To update it by applying a function to it, for example, the function that
+-- updates a stream by one unit, just do:
+--
+-- @
+-- expr = s ## x =$ (+1)
+-- @
 module Copilot.Language.Operators.Struct
   ( (#)
+  , Projection
+  , (##)
+  , (=:)
+  , (=$)
   ) where
 
 import Copilot.Core.Type
@@ -18,6 +45,46 @@ import GHC.TypeLits             (KnownSymbol)
 -- of type @Word8@, and @s@ is a stream of type @Stream T@, then @s # t2@ has
 -- type @Stream Word8@ and contains the values of the @t2@ field of the structs
 -- in @s@ at any point in time.
-(#) :: (KnownSymbol s, Typed t, Typed a, Struct a)
-      => Stream a -> (a -> Field s t) -> Stream t
+(#) :: (KnownSymbol f, Typed t, Typed s, Struct s)
+      => Stream s -> (s -> Field f t) -> Stream t
 (#) s f = Op1 (GetField typeOf typeOf f) s
+
+-- | Type represented an unapplied struct field accessor and a stream carrying
+-- structs.
+data Projection s f t = Projection (Stream s) (s -> Field f t)
+
+-- | Pair a stream with a field accessor, without applying it to obtain the
+-- value of the field.
+--
+-- This function is needed to refer to a field accessor when the goal is to
+-- update the field value, not just to read it.
+(##) :: (KnownSymbol f, Typed t, Typed s, Struct s)
+     => Stream s -> (s -> Field f t) -> Projection s f t
+(##) = Projection
+
+-- | Create a stream where the field of a struct has been updated with values
+-- from another stream.
+--
+-- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
+-- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and $sT1$
+-- is a stream of type @Int32@ then @s ## t2 =: sT1@ has type @Stream T@ and
+-- contains structs where the value of @t1@ is that of @sT1@ and the value of
+-- @t2@ is the value that the same field had in @s@, at any point in time.
+infixl 8 =:
+(=:) :: (KnownSymbol f, Typed t, Typed s, Struct s)
+     => Projection s f t -> Stream t -> Stream s
+(=:) (Projection s f) v = Op2 (UpdateField typeOf typeOf f) s v
+
+-- | Create a stream where the field of a struct has been updated by applying a
+-- function to it.
+--
+-- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
+-- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and $f$ is
+-- a function from @Stream Int32 -> Stream Int32@ then @s ## t2 =$ f@ has type
+-- @Stream T@ and contains structs where the value of @t1@ is that of @f@
+-- applied to the original value of @t1@ in @s@, and the value of @t2@ is the
+-- value that the same field had in @s@, at any point in time.
+infixl 8 =$
+(=$) :: (KnownSymbol f, Typed t, Typed s, Struct s)
+     => Projection s f t -> (Stream t -> Stream t) -> Stream s
+(=$) (Projection s f) op = s ## f =: (op (s # f))


### PR DESCRIPTION
Extend `copilot-language`, `copilot-core`, `copilot-interpreter` and `copilot-c99` to support struct field updates, as prescribed in the solution proposed for #520.