### PR TITLE
`copilot-prettyprinter`: Pretty-print struct update expressions. Refs #526.

### DIFF
--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-08-30
+        * Add support for pretty-printing struct update expressions. (#526)
+
 2024-07-07
         * Version bump (3.20). (#522)
 

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
@@ -100,6 +100,9 @@ ppOp2 op = case op of
   BwShiftL _ _ -> ppInfix "<<"
   BwShiftR _ _ -> ppInfix ">>"
   Index    _   -> ppInfix ".!!"
+  UpdateField (Struct _) _ f -> \ doc1 doc2 ->
+    parens $ doc1 <+> text "##" <+> text (accessorName f) <+> text "=:" <+> doc2
+  UpdateField _ _ _ -> impossible "ppOp2" "Copilot.PrettyPrint"
 
 -- | Pretty-print a ternary operation.
 ppOp3 :: Op3 a b c d -> Doc -> Doc -> Doc -> Doc


### PR DESCRIPTION
This adds support for pretty-printing expressions that update fields of a struct.

Fixes #526.