### PR TITLE
`copilot-language`: Add support for array element updates. Refs #36.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-03
+        * Add support for array updates. (#36)
+
 2024-07-07
         * Version bump (3.20). (#522)
         * Add support for struct field updates. (#520)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-03
+        * Update Op3, Array to support array updates. (#36)
+
 2024-07-07
         * Version bump (3.20). (#522)
         * Update Op2, Struct to support struct field updates. (#520)

--- a/copilot-core/src/Copilot/Core/Operators.hs
+++ b/copilot-core/src/Copilot/Core/Operators.hs
@@ -106,3 +106,6 @@ data Op2 a b c where
 data Op3 a b c d where
   -- Conditional operator.
   Mux :: Type a -> Op3 Bool a a a
+  -- Array operator.
+  UpdateArray :: Type (Array n t) -> Op3 (Array n t) Word32 t (Array n t)
+           -- ^ Update an element of an array.

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-03
+        * Add support for array updates. (#36)
+
 2024-07-07
         * Version bump (3.20). (#522)
         * Add support for struct field updates. (#520)

--- a/copilot-interpreter/src/Copilot/Interpret/Eval.hs
+++ b/copilot-interpreter/src/Copilot/Interpret/Eval.hs
@@ -19,8 +19,8 @@ module Copilot.Interpret.Eval
 import Copilot.Core            (Expr (..), Field (..), Id, Name, Observer (..),
                                 Op1 (..), Op2 (..), Op3 (..), Spec, Stream (..),
                                 Trigger (..), Type (..), UExpr (..), Value (..),
-                                arrayElems, specObservers, specStreams,
-                                specTriggers, updateField)
+				arrayElems, arrayUpdate, specObservers,
+                                specStreams, specTriggers, updateField)
 import Copilot.Interpret.Error (badUsage)
 
 import           Prelude hiding (id)
@@ -32,6 +32,7 @@ import Data.Dynamic      (Dynamic, fromDynamic, toDyn)
 import Data.List         (transpose)
 import Data.Maybe        (fromJust)
 import Data.Typeable     (Typeable)
+import GHC.TypeLits      (KnownNat, Nat, natVal)
 
 -- | Exceptions that may be thrown during interpretation of a Copilot
 -- specification.
@@ -265,7 +266,8 @@ catchZero f x y = f x y
 -- Haskell function operating on the same types as the
 -- 'Copilot.Core.Operators.Op3'.
 evalOp3 :: Op3 a b c d -> (a -> b -> c -> d)
-evalOp3 (Mux _) = \ !v !x !y -> if v then x else y
+evalOp3 (Mux         _)  = \ !v !x !y -> if v then x else y
+evalOp3 (UpdateArray ty) = \xs n x -> arrayUpdate xs (fromIntegral n) x
 
 -- | Turn a stream into a key-value pair that can be added to an 'Env' for
 -- simulation.

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-03
+        * Add support for array updates. (#36)
+
 2024-07-07
         * Version bump (3.20). (#522)
         * Remove deprecated function Copilot.Language.Spec.forall. (#518)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -61,6 +61,7 @@ library
                  , Copilot.Language.Operators.Ord
                  , Copilot.Language.Operators.Temporal
                  , Copilot.Language.Operators.Array
+                 , Copilot.Language.Operators.Projection
                  , Copilot.Language.Operators.Struct
                  , Copilot.Language.Prelude
                  , Copilot.Language.Reify

--- a/copilot-language/src/Copilot/Language/Operators/Array.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Array.hs
@@ -5,6 +5,7 @@
 -- | Combinators to deal with streams carrying arrays.
 module Copilot.Language.Operators.Array
   ( (.!!)
+  , (!)
   ) where
 
 import Copilot.Core             ( Typed
@@ -16,6 +17,15 @@ import Copilot.Language.Stream  (Stream (..))
 
 import Data.Word                (Word32)
 import GHC.TypeLits             (KnownNat)
+-- | Create a stream that carries an element of an array in another stream.
+--
+-- This function implements a projection of the element of an array at a given
+-- position, over time. For example, if @s@ is a stream of type @Stream (Array
+-- '5 Word8)@, then @s ! 3@ has type @Stream Word8@ and contains the 3rd
+-- element (starting from zero) of the arrays in @s@ at any point in time.
+(!) :: (KnownNat n, Typed t)
+    => Stream (Array n t) -> Stream Word32 -> Stream t
+arr ! n = Op2 (Index typeOf) arr n
 
 -- | Create a stream that carries an element of an array in another stream.
 --
@@ -23,7 +33,8 @@ import GHC.TypeLits             (KnownNat)
 -- position, over time. For example, if @s@ is a stream of type @Stream (Array
 -- '5 Word8)@, then @s .!! 3@ has type @Stream Word8@ and contains the 3rd
 -- element (starting from zero) of the arrays in @s@ at any point in time.
+{-# DEPRECATED (.!!) "This function is deprecated in Copilot 4. Use (!)." #-}
 (.!!) :: ( KnownNat n
          , Typed t
          ) => Stream (Array n t) -> Stream Word32 -> Stream t
-arr .!! n = Op2 (Index typeOf) arr n
+(.!!) = (!)

--- a/copilot-language/src/Copilot/Language/Operators/Array.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Array.hs
@@ -1,22 +1,29 @@
-{-# LANGUAGE Safe         #-}
-
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Safe                  #-}
+{-# LANGUAGE TypeFamilies          #-}
+-- The following warning is disabled due to a necessary instance of Projectable
+-- defined in this module.
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Combinators to deal with streams carrying arrays.
 module Copilot.Language.Operators.Array
   ( (.!!)
   , (!)
+  , (!!)
+  , (=:)
+  , (=$)
   ) where
 
-import Copilot.Core             ( Typed
-                                , Op2 (Index)
-                                , typeOf
-                                , Array
-                                )
-import Copilot.Language.Stream  (Stream (..))
+import Copilot.Core                          (Array, Op2 (Index),
+                                              Op3 (UpdateArray), Typed, typeOf)
+import Copilot.Language.Operators.Projection (Projectable(..))
+import Copilot.Language.Stream               (Stream (..))
 
-import Data.Word                (Word32)
-import GHC.TypeLits             (KnownNat)
+import Data.Word    (Word32)
+import GHC.TypeLits (KnownNat)
+import Prelude      hiding ((!!))
+
 -- | Create a stream that carries an element of an array in another stream.
 --
 -- This function implements a projection of the element of an array at a given
@@ -38,3 +45,45 @@ arr ! n = Op2 (Index typeOf) arr n
          , Typed t
          ) => Stream (Array n t) -> Stream Word32 -> Stream t
 (.!!) = (!)
+
+-- | Pair a stream with an element accessor, without applying it to obtain the
+-- value of the element.
+--
+-- This function is needed to refer to an element accessor when the goal is to
+-- update the element value, not just to read it.
+(!!) :: Stream (Array n t)
+     -> Stream Word32
+     -> Projection (Array n t) (Stream Word32) t
+(!!) = ProjectionA
+
+-- | Update a stream of arrays.
+
+-- This is an orphan instance; we suppress the warning that GHC would
+-- normally produce with a GHC option at the top.
+instance (KnownNat n, Typed t) => Projectable (Array n t) (Stream Word32) t where
+
+  -- | A projection of an element of a stream of arrays.
+  data Projection (Array n t) (Stream Word32) t =
+       ProjectionA (Stream (Array n t)) (Stream Word32)
+
+  -- | Create a stream where an element of an array has been updated with
+  -- values from another stream.
+  --
+  -- For example, if an array has two elements of type @Int32@, and @s@ is a
+  -- stream of such array type (@Stream (Array 2 Int32)@), and $v0$ is a stream
+  -- of type @Int32@, then @s !! 0 =: v0@ has type @Stream (Array 2 Int32)@ and
+  -- contains arrays where the value of the first element of each array is that
+  -- of @v0@ at each point in time, and the value of the second element in the
+  -- array is the same it had in @s@.
+  (=:) (ProjectionA s ix) v = Op3 (UpdateArray typeOf) s ix v
+
+  -- | Create a stream where an element of an array has been updated by
+  -- applying a stream function to it.
+  --
+  -- For example, if an array has two elements of type @Int32@, and @s@ is a
+  -- stream of such array type (@Stream (Array 2 Int32)@), and $f$ is function
+  -- of type @Stream Int32 -> Stream Int32@, then @s !! 0 =$ f@ has type
+  -- @Stream (Array 2 Int32)@ and contains arrays where the value of the first
+  -- element of each array is that of @f (s ! 0)@ at each point in time, and
+  -- the value of the second element in the array is the same it had in @s@.
+  (=$) (ProjectionA s ix) op = Op3 (UpdateArray typeOf) s ix (op (s ! ix))

--- a/copilot-language/src/Copilot/Language/Operators/Projection.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Projection.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies           #-}
+-- | Interface to access portions of a larger data structure.
+--
+-- Default operations to access elements from structs and arrays (e.g., a field
+-- of a struct, an element of an array) allow obtaining the values of those
+-- elements, but not modifying.
+--
+-- This module defines a common interface to manipulate portions of a larger
+-- data structure. We define the interface in a generic way, using a type
+-- class with two operations: one to set the value of the sub-element, and
+-- one to update the value of such element applying a stream function.
+module Copilot.Language.Operators.Projection
+    ( Projectable (..) )
+  where
+
+import Copilot.Language.Stream (Stream)
+
+infixl 8 =:
+infixl 8 =$
+
+-- | Common interface to manipulate portions of a larger data structure.
+--
+-- A projectable d s t means that it is possible to manipulate a sub-element s
+-- of type t carried in a stream of type d..
+class Projectable d s t | d s -> t where
+
+  -- | Unapplied projection or element access on a type.
+  data Projection d s t
+
+  -- | Modify the value of a sub-element of a type in a stream of elements
+  -- of that type.
+  (=:) :: Projection d s t -> Stream t -> Stream d
+
+  -- | Update the value of a sub-element of a type in a stream of elements of
+  -- that type, by applying a function on streams.
+  (=$) :: Projection d s t -> (Stream t -> Stream t) -> Stream d

--- a/copilot-language/src/Copilot/Language/Operators/Struct.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Struct.hs
@@ -1,4 +1,10 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Safe                  #-}
+{-# LANGUAGE TypeFamilies          #-}
+-- The following warning is disabled due to a necessary instance of Projectable
+-- defined in this module.
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Combinators to deal with streams carrying structs.
 --
@@ -25,18 +31,17 @@
 -- expr = s ## x =$ (+1)
 -- @
 module Copilot.Language.Operators.Struct
-  ( (#)
-  , Projection
+  ( Projectable(..)
+  , (#)
   , (##)
-  , (=:)
-  , (=$)
   ) where
 
 import Copilot.Core.Type
 import Copilot.Core.Operators
-import Copilot.Language.Stream  (Stream (..))
+import Copilot.Language.Operators.Projection
+import Copilot.Language.Stream               (Stream (..))
 
-import GHC.TypeLits             (KnownSymbol)
+import GHC.TypeLits (KnownSymbol)
 
 -- | Create a stream that carries a field of a struct in another stream.
 --
@@ -49,42 +54,44 @@ import GHC.TypeLits             (KnownSymbol)
       => Stream s -> (s -> Field f t) -> Stream t
 (#) s f = Op1 (GetField typeOf typeOf f) s
 
--- | Type represented an unapplied struct field accessor and a stream carrying
--- structs.
-data Projection s f t = Projection (Stream s) (s -> Field f t)
-
 -- | Pair a stream with a field accessor, without applying it to obtain the
 -- value of the field.
 --
 -- This function is needed to refer to a field accessor when the goal is to
 -- update the field value, not just to read it.
 (##) :: (KnownSymbol f, Typed t, Typed s, Struct s)
-     => Stream s -> (s -> Field f t) -> Projection s f t
-(##) = Projection
+     => Stream s -> (s -> Field f t) -> Projection s (s -> Field f t) t
+(##) = ProjectionS
 
--- | Create a stream where the field of a struct has been updated with values
--- from another stream.
---
--- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
--- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and $sT1$
--- is a stream of type @Int32@ then @s ## t2 =: sT1@ has type @Stream T@ and
--- contains structs where the value of @t1@ is that of @sT1@ and the value of
--- @t2@ is the value that the same field had in @s@, at any point in time.
-infixl 8 =:
-(=:) :: (KnownSymbol f, Typed t, Typed s, Struct s)
-     => Projection s f t -> Stream t -> Stream s
-(=:) (Projection s f) v = Op2 (UpdateField typeOf typeOf f) s v
+-- | Update a stream of structs.
 
--- | Create a stream where the field of a struct has been updated by applying a
--- function to it.
---
--- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
--- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and $f$ is
--- a function from @Stream Int32 -> Stream Int32@ then @s ## t2 =$ f@ has type
--- @Stream T@ and contains structs where the value of @t1@ is that of @f@
--- applied to the original value of @t1@ in @s@, and the value of @t2@ is the
--- value that the same field had in @s@, at any point in time.
-infixl 8 =$
-(=$) :: (KnownSymbol f, Typed t, Typed s, Struct s)
-     => Projection s f t -> (Stream t -> Stream t) -> Stream s
-(=$) (Projection s f) op = s ## f =: (op (s # f))
+-- This is an orphan instance; we suppress the warning that GHC would
+-- normally produce with a GHC option at the top.
+instance (KnownSymbol f, Typed s, Typed t, Struct s)
+      => Projectable s (s -> Field f t) t
+  where
+
+  -- | A projection of a field of a stream of structs.
+  data Projection s (s -> Field f t) t = ProjectionS (Stream s) (s -> Field f t)
+
+  -- | Create a stream where the field of a struct has been updated with values
+  -- from another stream.
+  --
+  -- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
+  -- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and
+  -- $sT1$ is a stream of type @Int32@ then @s ## t2 =: sT1@ has type @Stream
+  -- T@ and contains structs where the value of @t1@ is that of @sT1@ and the
+  -- value of @t2@ is the value that the same field had in @s@, at any point in
+  -- time.
+  (=:) (ProjectionS s f) v = Op2 (UpdateField typeOf typeOf f) s v
+
+  -- | Create a stream where the field of a struct has been updated by applying
+  -- a function to it.
+  --
+  -- For example, if a struct of type @T@ has two fields, @t1@ of type @Int32@
+  -- and @t2@ of type @Word8@, and @s@ is a stream of type @Stream T@, and $f$
+  -- is a function from @Stream Int32 -> Stream Int32@ then @s ## t2 =$ f@ has
+  -- type @Stream T@ and contains structs where the value of @t1@ is that of
+  -- @f@ applied to the original value of @t1@ in @s@, and the value of @t2@ is
+  -- the value that the same field had in @s@, at any point in time.
+  (=$) (ProjectionS s f) op = Op2 (UpdateField typeOf typeOf f) s (op (s # f))

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-03
+        * Rename operator to avoid name clash. (#36)
+
 2024-07-07
         * Version bump (3.20). (#522)
 

--- a/copilot-libraries/src/Copilot/Library/Libraries.hs
+++ b/copilot-libraries/src/Copilot/Library/Libraries.hs
@@ -23,6 +23,6 @@ import Copilot.Library.LTL
 import Copilot.Library.PTLTL
 import Copilot.Library.Statistics
 import Copilot.Library.RegExp
-import Copilot.Library.Utils
+import Copilot.Library.Utils      hiding ((!!))
 import Copilot.Library.Voting
 import Copilot.Library.Stacks

--- a/copilot-libraries/src/Copilot/Library/Utils.hs
+++ b/copilot-libraries/src/Copilot/Library/Utils.hs
@@ -13,10 +13,10 @@ module Copilot.Library.Utils
          -- ** Scans
          nscanl, nscanr, nscanl1, nscanr1,
          -- ** Indexing
-         case', (!!))
+         case', (!!), (!!!))
 where
 
-import Copilot.Language
+import Copilot.Language hiding ((!!))
 import qualified Prelude as P
 
 -- | Given a stream, produce an infinite list of streams dropping an increasing
@@ -135,21 +135,28 @@ case' predicates alternatives =
 --
 -- WARNING: Very expensive! Consider using this only for very short lists.
 (!!) :: (Typed a, Eq b, Num b, Typed b) => [Stream a] -> Stream b -> Stream a
-ls !! n = let indices      = map
+(!!) = (!!!)
+{-# DEPRECATED (!!) "This function is deprecated in Copilot 4. Use (!!!)." #-}
+
+-- | Index.
+--
+-- WARNING: Very expensive! Consider using this only for very short lists.
+(!!!) :: (Typed a, Eq b, Num b, Typed b) => [Stream a] -> Stream b -> Stream a
+ls !!! n = let indices      = map
                              ( constant . fromIntegral )
                              [ 0 .. P.length ls - 1 ]
-              select [] _  = last ls
-              select
-                ( i : is )
-                ( x : xs ) = mux ( i == n ) x ( select is xs )
-                             -- should not happen
-              select _ []  = badUsage ("in (!!) defined in Utils.hs " P.++
-                               "in copilot-libraries")
-          in if null ls then
-               badUsage ("in (!!) defined in Utils.hs " P.++
-                            "indexing the empty list with !! is not defined")
-             else
-               select indices ls
+               select [] _  = last ls
+               select
+                 ( i : is )
+                 ( x : xs ) = mux ( i == n ) x ( select is xs )
+                              -- should not happen
+               select _ []  = badUsage ("in (!!) defined in Utils.hs " P.++
+                                "in copilot-libraries")
+           in if null ls then
+                badUsage ("in (!!) defined in Utils.hs " P.++
+                             "indexing the empty list with !! is not defined")
+              else
+                select indices ls
 
 -- | Cycle a list to form an infinite stream.
 cycle :: ( Typed a ) => [ a ] -> Stream a

--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,5 +1,6 @@
-2024-08-30
+2024-09-03
         * Add support for pretty-printing struct update expressions. (#526)
+        * Add support for pretty-printing array update expressions. (#36)
 
 2024-07-07
         * Version bump (3.20). (#522)

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
@@ -111,6 +111,8 @@ ppOp3 op = case op of
     text "(if"   <+> doc1 <+>
     text "then" <+> doc2 <+>
     text "else" <+> doc3 <> text ")"
+  UpdateArray _ -> \ doc1 doc2 doc3 ->
+    parens $ doc1 <+> text "!!" <+> doc2 <+> text "=:" <+> doc3
 
 -- | Parenthesize two 'Doc's, separated by an infix 'String'.
 ppInfix :: String -> Doc -> Doc -> Doc

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
@@ -99,7 +99,7 @@ ppOp2 op = case op of
   BwXor    _   -> ppInfix "^"
   BwShiftL _ _ -> ppInfix "<<"
   BwShiftR _ _ -> ppInfix ">>"
-  Index    _   -> ppInfix ".!!"
+  Index    _   -> ppInfix "!"
   UpdateField (Struct _) _ f -> \ doc1 doc2 ->
     parens $ doc1 <+> text "##" <+> text (accessorName f) <+> text "=:" <+> doc2
   UpdateField _ _ _ -> impossible "ppOp2" "Copilot.PrettyPrint"

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,6 @@
-2024-08-30
+2024-09-03
         * Add support for struct updates in Copilot.Theorem.What4. (#524)
+        * Add support for array updates in Copilot.Theorem.What4. (#36)
 
 2024-07-07
         * Version bump (3.20). (#522)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,5 +1,6 @@
-2024-08-30
+2024-09-03
         * Update example to demonstrate struct update support. (#524)
+        * Update example to demonstrate array update support. (#36)
 
 2024-07-07
         * Version bump (3.20). (#522)

--- a/copilot/examples/Array.hs
+++ b/copilot/examples/Array.hs
@@ -26,7 +26,7 @@ spec = do
   -- It passes the current value of arr as an argument.
   -- The prototype of 'func' would be:
   -- void func (int8_t arg[3]);
-  trigger "func" (arr .!! 0) [arg arr]
+  trigger "func" (arr ! 0) [arg arr]
 
 -- Compile the spec
 main :: IO ()

--- a/copilot/examples/Array.hs
+++ b/copilot/examples/Array.hs
@@ -28,6 +28,20 @@ spec = do
   -- void func (int8_t arg[3]);
   trigger "func" (arr ! 0) [arg arr]
 
+  -- A trigger that fires 'func2' every time.
+  -- It passes the current value of arr as an argument, but updating the first
+  -- element of the array to always be True.
+  -- The prototype of 'func2' would be:
+  -- void func2 (int8_t arg[3]);
+  trigger "func2" true [arg (arr !! 0 =: true)]
+
+  -- A trigger that fires 'func2' every time.
+  -- It passes the current value of arr as an argument, but negating the second
+  -- element of the array.
+  -- The prototype of 'func3' would be:
+  -- void func3 (int8_t arg[3]);
+  trigger "func3" true [arg (arr !! 1 =$ not)]
+
 -- Compile the spec
 main :: IO ()
 main = interpret 30 spec

--- a/copilot/examples/Structs.hs
+++ b/copilot/examples/Structs.hs
@@ -56,13 +56,13 @@ spec = do
   -- Check equality, indexing into nested structs and arrays. Note that this is
   -- trivial by equality.
   trigger "equalitySameIndex"
-    ((((battery#volts) .!! 0)#numVolts) == (((battery#volts) .!! 0)#numVolts))
+    ((((battery#volts) ! 0)#numVolts) == (((battery#volts) ! 0)#numVolts))
     [arg battery]
 
   -- Same as previous example, but get a different array index (so should be
   -- false).
   trigger "equalityDifferentIndices"
-    ((((battery#other) .!! 2) .!! 3) == (((battery#other) .!! 2) .!! 4))
+    ((((battery#other) ! 2) ! 3) == (((battery#other) ! 2) ! 4))
     [arg battery]
 
 main :: IO ()

--- a/copilot/examples/what4/Arrays.hs
+++ b/copilot/examples/what4/Arrays.hs
@@ -1,0 +1,42 @@
+-- | An example showing the usage of the What4 backend in copilot-theorem for
+-- arrays where individual elements are updated.
+
+{-# LANGUAGE DataKinds #-}
+
+module Main where
+
+import qualified Prelude as P
+import Control.Monad (void, forM_)
+
+import Language.Copilot
+import Copilot.Theorem.What4
+
+spec :: Spec
+spec = do
+  let pair :: Stream (Array 2 Int16)
+      pair = extern "pair" Nothing
+
+  -- Check equality, indexing into array and modifying the value. Note that
+  -- this is trivial by equality.
+  void $ prop "Example 1" $ forAll $
+    ((pair !! 0 =$ (+1)) ! 0) == ((pair ! 0) + 1)
+
+  -- Same as previous example, but get a different array index (so should be
+  -- false).
+  void $ prop "Example 2" $ forAll $
+    ((pair !! 0 =$ (+1)) ! 1) == ((pair ! 0) + 1)
+
+main :: IO ()
+main = do
+  spec' <- reify spec
+
+  -- Use Z3 to prove the properties.
+  results <- prove Z3 spec'
+
+  -- Print the results.
+  forM_ results $ \(nm, res) -> do
+    putStr $ nm <> ": "
+    case res of
+      Valid   -> putStrLn "valid"
+      Invalid -> putStrLn "invalid"
+      Unknown -> putStrLn "unknown"

--- a/copilot/examples/what4/Structs.hs
+++ b/copilot/examples/what4/Structs.hs
@@ -57,12 +57,12 @@ spec = do
   -- Check equality, indexing into nested structs and arrays. Note that this is
   -- trivial by equality.
   void $ prop "Example 1" $ forAll $
-    (((battery#volts) .!! 0)#numVolts) == (((battery#volts) .!! 0)#numVolts)
+    (((battery#volts) ! 0)#numVolts) == (((battery#volts) ! 0)#numVolts)
 
   -- Same as previous example, but get a different array index (so should be
   -- false).
   void $ prop "Example 2" $ forAll $
-    (((battery#other) .!! 2) .!! 3) == (((battery#other) .!! 2) .!! 4)
+    (((battery#other) ! 2) ! 3) == (((battery#other) ! 2) ! 4)
 
   -- Update a struct field, then check it for equality.
   void $ prop "Example 3" $ forAll $


### PR DESCRIPTION
Extend `copilot-language` and all other libraries to support array element updates, as prescribed in the solution proposed for #36.