### PR TITLE
Release 4.0. Refs #532.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Add support for array updates. (#36)
 
 2024-07-07

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-c99
-version                   : 3.20
+version                   : 4.0
 synopsis                  : A compiler for Copilot targeting C99.
 description               :
   This package is a back-end from Copilot to C.
@@ -45,7 +45,7 @@ library
                           , mtl                 >= 2.2 && < 2.4
                           , pretty              >= 1.1 && < 1.2
 
-                          , copilot-core        >= 3.20  && < 3.21
+                          , copilot-core        >= 4.0   && < 4.1
                           , language-c99        >= 0.2.0 && < 0.3
                           , language-c99-simple >= 0.3   && < 0.4
 

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Update Op3, Array to support array updates. (#36)
 
 2024-07-07

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-core
-version:             3.20
+version:             4.0
 synopsis:            An intermediate representation for Copilot.
 description:
   Intermediate representation for Copilot.

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Add support for array updates. (#36)
 
 2024-07-07

--- a/copilot-interpreter/copilot-interpreter.cabal
+++ b/copilot-interpreter/copilot-interpreter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-interpreter
-version:             3.20
+version:             4.0
 synopsis:            Interpreter for Copilot.
 description:
   Interpreter for Copilot.
@@ -44,7 +44,7 @@ library
     base       >= 4.9 && < 5,
     pretty     >= 1.0 && < 1.2,
 
-    copilot-core >= 3.20 && < 3.21
+    copilot-core >= 4.0 && < 4.1
 
   exposed-modules:
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Add support for array updates. (#36)
 
 2024-07-07

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-language
-version:             3.20
+version:             4.0
 synopsis:            A Haskell-embedded DSL for monitoring hard real-time
                      distributed systems.
 description:
@@ -42,9 +42,9 @@ library
                , data-reify            >= 0.6  && < 0.7
                , mtl                   >= 2.0  && < 3
 
-               , copilot-core          >= 3.20 && < 3.21
-               , copilot-interpreter   >= 3.20 && < 3.21
-               , copilot-theorem       >= 3.20 && < 3.21
+               , copilot-core          >= 4.0 && < 4.1
+               , copilot-interpreter   >= 4.0 && < 4.1
+               , copilot-theorem       >= 4.0 && < 4.1
 
   exposed-modules: Copilot.Language
                  , Copilot.Language.Operators.BitWise

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Rename operator to avoid name clash. (#36)
 
 2024-07-07

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-libraries
-version:             3.20
+version:             4.0
 synopsis:            Libraries for the Copilot language.
 description:
   Libraries for the Copilot language.
@@ -36,12 +36,12 @@ library
 
   hs-source-dirs: src
 
-  build-depends: base             >= 4.9  && < 5
+  build-depends: base             >= 4.9 && < 5
 
-               , containers       >= 0.4  && < 0.7
-               , mtl              >= 2.0  && < 2.4
-               , parsec           >= 2.0  && < 3.2
-               , copilot-language >= 3.20 && < 3.21
+               , containers       >= 0.4 && < 0.7
+               , mtl              >= 2.0 && < 2.4
+               , parsec           >= 2.0 && < 3.2
+               , copilot-language >= 4.0 && < 4.1
 
   exposed-modules:
       Copilot.Library.Libraries

--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Add support for pretty-printing struct update expressions. (#526)
         * Add support for pretty-printing array update expressions. (#36)
 

--- a/copilot-prettyprinter/copilot-prettyprinter.cabal
+++ b/copilot-prettyprinter/copilot-prettyprinter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-prettyprinter
-version:             3.20
+version:             4.0
 synopsis:            A prettyprinter of Copilot Specifications.
 description:
   A prettyprinter of Copilot specifications.
@@ -45,7 +45,7 @@ library
     base   >= 4.9 && < 5,
     pretty >= 1.0 && < 1.2,
 
-    copilot-core >= 3.20 && < 3.21
+    copilot-core >= 4.0 && < 4.1
 
   exposed-modules:
 

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Add support for struct updates in Copilot.Theorem.What4. (#524)
         * Add support for array updates in Copilot.Theorem.What4. (#36)
 

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -14,7 +14,7 @@ description:
   <https://copilot-language.github.io>.
 
 
-version                   : 3.20
+version                   : 4.0
 license                   : BSD3
 license-file              : LICENSE
 maintainer                : Ivan Perez <ivan.perezdominguez@nasa.gov>
@@ -63,8 +63,8 @@ library
                           , xml                   >= 1.3 && < 1.4
                           , what4                 >= 1.3 && < 1.7
 
-                          , copilot-core          >= 3.20 && < 3.21
-                          , copilot-prettyprinter >= 3.20 && < 3.21
+                          , copilot-core          >= 4.0 && < 4.1
+                          , copilot-prettyprinter >= 4.0 && < 4.1
 
   exposed-modules         : Copilot.Theorem
                           , Copilot.Theorem.Prove

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,4 +1,5 @@
-2024-09-03
+2024-09-07
+        * Version bump (4.0). (#532)
         * Update example to demonstrate struct update support. (#524)
         * Update example to demonstrate array update support. (#36)
 

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -1,5 +1,5 @@
 name:                copilot
-version:             3.20
+version:             4.0
 cabal-version:       >= 1.10
 license:             BSD3
 license-file:        LICENSE
@@ -52,12 +52,12 @@ library
                      , directory             >= 1.3  && < 1.4
                      , filepath              >= 1.4  && < 1.5
 
-                     , copilot-core          >= 3.20 && < 3.21
-                     , copilot-theorem       >= 3.20 && < 3.21
-                     , copilot-language      >= 3.20 && < 3.21
-                     , copilot-libraries     >= 3.20 && < 3.21
-                     , copilot-c99           >= 3.20 && < 3.21
-                     , copilot-prettyprinter >= 3.20 && < 3.21
+                     , copilot-core          >= 4.0 && < 4.1
+                     , copilot-theorem       >= 4.0 && < 4.1
+                     , copilot-language      >= 4.0 && < 4.1
+                     , copilot-libraries     >= 4.0 && < 4.1
+                     , copilot-c99           >= 4.0 && < 4.1
+                     , copilot-prettyprinter >= 4.0 && < 4.1
 
 
     exposed-modules: Language.Copilot, Language.Copilot.Main


### PR DESCRIPTION
This PR updates the version numbers of all packages, as well as the version bounds of all dependencies on Copilot, as prescribed in the solution proposed for #532.