### PR TITLE
`copilot-language`: Detect duplicate extern names in properties and theorems. Refs #536.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-15
+        * Reject duplicate externs in properties and theorems. (#536)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Add support for array updates. (#36)


### PR DESCRIPTION
The Copilot analysis functionality in `Copilot.Language.Analyze` was able to detect distinct externs with the same name (something that should be rejected with a proper error message) in triggers and observers, but not in properties or theorems. As a consequence of this, `copilot-theorem` could outright crash when attempting to prove properties in a specification with duplicate extern names.

This fixes the issue by extending the analysis functionality to look into properties and theorems as well.

Fixes #536.