### PR TITLE
`copilot`: Update `what4-propositional` example's comments to match results. Refs #535.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,6 +1,7 @@
-2024-10-14
+2024-10-18
         * Update contribution guidelines (#476).
         * Update README with missing publications. (#544)
+        * Make the what4-propositional example's comments match results. (#535)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot/examples/what4/Propositional.hs
+++ b/copilot/examples/what4/Propositional.hs
@@ -11,40 +11,65 @@ import Copilot.Theorem.What4
 
 spec :: Spec
 spec = do
+  -- * Non-inductive propositions
+
   -- The constant value true, which is translated as the corresponding SMT
-  -- boolean literal.
+  -- boolean literal (and is therefore provable).
   void $ prop "Example 1" (forAll true)
 
   -- The constant value false, which is translated as the corresponding SMT
-  -- boolean literal.
+  -- boolean literal (and is therefore not provable).
   void $ prop "Example 2" (forAll false)
 
-  -- An inductively defined flavor of true, which requires induction to prove,
-  -- and hence is found to be invalid by the SMT solver (since no inductive
-  -- hypothesis is made).
-  let a = [True] ++ a
-  void $ prop "Example 3" (forAll a)
-
-  -- An inductively defined "a or not a" proposition, which is unprovable by
-  -- the SMT solver.
-  let a = [False] ++ b
-      b = [True] ++ a
-  void $ prop "Example 4" (forAll (a || b))
-
-  -- A version of "a or not a" proposition which does not require any sort of
-  -- inductive argument, and hence is provable.
+  -- An "a or not a" proposition which does not require any sort of inductive
+  -- argument (but see examples 5 and 6 below for versions that do require
+  -- induction to solve). This is easily proven.
   let a = [False] ++ b
       b = not a
-  void $ prop "Example 5" (forAll (a || b))
+  void $ prop "Example 3" (forAll (a || b))
 
-  -- A bit more convoluted version of Example 5, which is provable.
-  let a = [True, False] ++ b
-      b = [False] ++ not (drop 1 a)
+  -- An "a or not a" proposition using external streams, which is also provable.
+  let a = extern "a" Nothing
+  void $ prop "Example 4" (forAll (a || not a))
+
+  -- * Simple inductive propositions
+  --
+  -- While Copilot.Theorem.What4 is not able to solve all inductive propositions
+  -- in general (see the "Complex inductive propositions" section below), the
+  -- following inductive propositions are simple enough that the heuristics in
+  -- Copilot.Theorem.What4 can solve them without issue.
+
+  -- An inductively defined flavor of true.
+  let a = [True] ++ a
+  void $ prop "Example 5" (forAll a)
+
+  -- An inductively defined "a or not a" proposition (i.e., a more complex
+  -- version of example 3 above).
+  let a = [False] ++ b
+      b = [True] ++ a
   void $ prop "Example 6" (forAll (a || b))
 
-  -- An example using external streams.
-  let a = extern "a" Nothing
-  void $ prop "Example 7" (forAll (a || not a))
+  -- A bit more convoluted version of example 6.
+  let a = [True, False] ++ b
+      b = [False] ++ not (drop 1 a)
+  void $ prop "Example 7" (forAll (a || b))
+
+  -- * Complex induction propositions
+  --
+  -- The heuristics in Copilot.Theorem.What4 are not able to prove these
+  -- inductive propositions, so these will be reported as unprovable, even
+  -- though each proposition is actually provable.
+
+  -- An inductively defined flavor of true (i.e., a more complex version of
+  -- example 5 above).
+  let a = [True] ++ ([True] ++ ([True] ++ a))
+  void $ prop "Example 8" (forAll a)
+
+  -- An inductively defined "a or not a" proposition (i.e., a more complex
+  -- version of example 6 above).
+  let a = [False] ++ ([False] ++ ([False] ++ b))
+      b = [True] ++ ([True] ++ ([True] ++ a))
+  void $ prop "Example 9" (forAll (a || b))
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Previously, the comments in the `what4-propositional` example claimed that certain examples were unprovable, even though they were actually provable. This is a result of the heuristics in `Copilot.Theorem.What4` becoming more intelligent after commit https://github.com/Copilot-Language/copilot/commit/4ae3f249fbf8c37c0909046150ff341d432bd042, but due to an oversight, the comments in the `what4-propositional` example were not updated at the time.

This commit revamps the `what4-propositional` example so that each example's comments clearly and accurately state whether the example is provable with the current implementation of `Copilot.Theorem.What4`. I have organized the examples so that they are organized into logically separate sections, with each section requiring increasingly more sophisticated techniques to prove (or, in some cases, fail to prove).

Fixes #535.