### PR TITLE
Add Haddocks for `updateField` and describe how to implement it. Refs #525.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-18
+        * Add Haddocks for updateField. (#525)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Update Op3, Array to support array updates. (#36)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -60,6 +60,25 @@ class Struct a where
   -- | Transforms all the struct's fields into a list of values.
   toValues :: a -> [Value a]
 
+  -- | Update the value of a struct field. This is only used by the Copilot
+  -- interpreter, so if you do not plan to use the interpreter, it is safe to
+  -- omit an implementation of this method.
+  --
+  -- In order to implement 'updateField', you should do the following for each
+  -- 'Field' in a struct:
+  --
+  -- 1. Check that the name of the 'Field' matches the name of the supplied
+  --    'Value' (using 'GHC.TypeLits.sameSymbol').
+  --
+  -- 2. Check that the type of the 'Field' matches the 'Type' of the supplied
+  --    'Value' (using 'DE.testEquality').
+  --
+  -- 3. If both (1) and (2) succeed, update the corresponding struct field using
+  --    a record update.
+  --
+  -- For a complete end-to-end example that demonstrates how to implement
+  -- 'updateField' and use it in the Copilot interpreter, see the
+  -- @examples/StructsUpdateField.hs@ example in the @copilot@ library.
   updateField :: a -> Value t -> a
   updateField = error "Field updates not supported for this type."
 

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -80,7 +80,10 @@ class Struct a where
   -- 'updateField' and use it in the Copilot interpreter, see the
   -- @examples/StructsUpdateField.hs@ example in the @copilot@ library.
   updateField :: a -> Value t -> a
-  updateField = error "Field updates not supported for this type."
+  updateField = error $ unlines
+    [ "Field updates not supported for this type."
+    , "(Perhaps you need to implement 'updateField' for a 'Struct' instance?)"
+    ]
 
 -- | The field of a struct, together with a representation of its type.
 data Value a =

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -2,6 +2,7 @@
         * Update contribution guidelines (#476).
         * Update README with missing publications. (#544)
         * Make the what4-propositional example's comments match results. (#535)
+        * Add example describing how to implement updateField. (#525)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -207,6 +207,18 @@ executable structs
     else
       buildable: False
 
+executable structs-update-field
+    main-is:            StructsUpdateField.hs
+    hs-source-dirs:     examples
+    build-depends:      base              >= 4.9  && < 5
+                      , copilot
+                      , copilot-c99
+    default-language:   Haskell2010
+    if flag(examples)
+      buildable: True
+    else
+      buildable: False
+
 executable voting
     main-is:            Voting.hs
     hs-source-dirs:     examples

--- a/copilot/examples/Structs.hs
+++ b/copilot/examples/Structs.hs
@@ -23,6 +23,11 @@ instance Struct Volts where
   toValues volts = [ Value Word16 (numVolts volts)
                    , Value Bool   (flag volts)
                    ]
+  -- Note that we do not implement `updateField` here. `updateField` is only
+  -- needed to make updates to structs work in the Copilot interpreter, and we
+  -- do not use the interpreter in this example. (See
+  -- `examples/StructsUpdateField.hs` for an example that does implement
+  -- `updateField`.)
 
 -- | `Volts` instance for `Typed`.
 instance Typed Volts where
@@ -41,6 +46,8 @@ instance Struct Battery where
                      , Value typeOf (volts battery)
                      , Value typeOf (other battery)
                      ]
+  -- Note that we do not implement `updateField` here for the same reasons as in
+  -- the `Struct Volts` instance above.
 
 -- | `Battery` instance for `Typed`. Note that `undefined` is used as an
 -- argument to `Field`. This argument is never used, so `undefined` will never

--- a/copilot/examples/StructsUpdateField.hs
+++ b/copilot/examples/StructsUpdateField.hs
@@ -1,0 +1,159 @@
+-- | An example showing how specifications involving structs (in particular,
+-- nested structs) are interpreted and how they are compiled to C using
+-- copilot-c99.
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import qualified Prelude as P
+import Control.Monad (void, forM_)
+import Data.Proxy (Proxy(..))
+import Data.Type.Equality (TestEquality(..), (:~:)(..))
+import GHC.TypeLits (sameSymbol)
+
+import Language.Copilot
+import Copilot.Compile.C99
+
+-- | Definition for `Volts`.
+data Volts = Volts
+  { numVolts :: Field "numVolts" Word16
+  , flag     :: Field "flag"     Bool
+  }
+
+-- | `Struct` instance for `Volts`.
+instance Struct Volts where
+  typeName _ = "volts"
+  toValues volts = [ Value Word16 (numVolts volts)
+                   , Value Bool   (flag volts)
+                   ]
+  -- In order to run struct updates (as used in the "equalityStructUpdate"
+  -- trigger below) in the Copilot interpreter, we must implement the
+  -- `updateField` method. To do so, we must check to see if the supplied
+  -- `Value` has a `Field` with the same name and type as a field in `Volts`.
+  updateField volts (Value fieldTy (field :: Field fieldName a))
+      -- For each field in `Volts`, we must:
+      --
+      -- 1. Check that the field names match using `sameSymbol`. Here,
+      --    "numVolts" is the expected name, and `fieldName` is the actual name
+      --    that is supplied as an argument to `updateField`. If the check
+      --    succeeds, then the `sameSymbol` function will return `Just p`, where
+      --    `p` is proof that the two names are the same.
+    | Just Refl <- sameSymbol (Proxy @"numVolts") (Proxy @fieldName)
+      -- 2. Check that the field types match using `testEquality`. Here,
+      --    `Word16` is the expected type, and `fieldTy` is the actual type that
+      --    is supplied as an argument. Again, `testEquality` will return `Just
+      --    p` (where `p` is a proof) if the two are the same.
+    , Just Refl <- testEquality Word16 fieldTy
+      -- 3. If both of the checks above succeed, then we can update the field's
+      --    value using a record update.
+    = volts { numVolts = field }
+
+      -- It is possible that the `Value` passed as an argument could correspond
+      -- to any of the fields in `Volts`, so we must repeat this process for
+      -- the `flag` field as well.
+    | Just Refl <- sameSymbol (Proxy @fieldName) (Proxy @"flag")
+    , Just Refl <- testEquality fieldTy Bool
+    = volts { flag = field }
+
+      -- If the supplied `Value` does not correspond to any field in `Volts`,
+      -- then something went wrong in the Copilot interpreter. This case reports
+      -- this as an error.
+    | otherwise
+    = error $ "Unexpected field: " P.++ show field
+
+-- | `Volts` instance for `Typed`.
+instance Typed Volts where
+  typeOf = Struct (Volts (Field 0) (Field False))
+
+data Battery = Battery
+  { temp  :: Field "temp"  Word16
+  , volts :: Field "volts" (Array 10 Volts)
+  , other :: Field "other" (Array 10 (Array 5 Word32))
+  }
+
+-- | `Battery` instance for `Struct`.
+instance Struct Battery where
+  typeName _ = "battery"
+  toValues battery = [ Value typeOf (temp battery)
+                     , Value typeOf (volts battery)
+                     , Value typeOf (other battery)
+                     ]
+  -- We implement `updateField` similarly to how we implement it in the
+  -- `Struct Volts` instance above.
+  updateField battery (Value fieldTy (field :: Field fieldName a))
+    | Just Refl <- sameSymbol (Proxy @fieldName) (Proxy @"temp")
+    , Just Refl <- testEquality fieldTy Word16
+    = battery { temp = field }
+
+    | Just Refl <- sameSymbol (Proxy @fieldName) (Proxy @"volts")
+      -- Note that writing out the full `Type` for `Volts` is somewhat verbose,
+      -- so we make use of the `Typed Volts` instance and write `typeOf @Volts`
+      -- instead.
+    , Just Refl <- testEquality fieldTy (Array @10 (typeOf @Volts))
+    = battery { volts = field }
+
+    | Just Refl <- sameSymbol (Proxy @fieldName) (Proxy @"other")
+    , Just Refl <- testEquality fieldTy (Array @10 (Array @5 Word32))
+    = battery { other = field }
+
+    | otherwise
+    = error $ "Unexpected field: " P.++ show field
+
+-- | `Battery` instance for `Typed`. Note that `undefined` is used as an
+-- argument to `Field`. This argument is never used, so `undefined` will never
+-- throw an error.
+instance Typed Battery where
+  typeOf = Struct (Battery (Field 0) (Field undefined) (Field undefined))
+
+spec :: Spec
+spec = do
+  let voltsValue :: Volts
+      voltsValue =
+        Volts
+          { numVolts = Field 42
+          , flag = Field True
+          }
+
+      batteryValue :: Battery
+      batteryValue =
+        Battery
+          { temp = Field 0
+          , volts = Field (array (replicate 10 voltsValue))
+          , other = Field (array (replicate 10 (array (replicate 5 0))))
+          }
+
+      battery :: Stream Battery
+      battery = extern "battery" (Just [batteryValue])
+
+  -- Check equality, indexing into nested structs and arrays. Note that this is
+  -- trivial by equality.
+  trigger "equalitySameIndex"
+    ((((battery#volts) ! 0)#numVolts) == (((battery#volts) ! 0)#numVolts))
+    [arg battery]
+
+  -- Same as previous example, but get a different array index (so should be
+  -- false).
+  trigger "equalityDifferentIndices"
+    ((((battery#other) ! 2) ! 3) == (((battery#other) ! 2) ! 4))
+    [arg battery]
+
+  -- Update a struct field, then check it for equality.
+  let batteryTemp1, batteryTemp2 :: Stream Word16
+      batteryTemp1 = (battery ## temp =$ (+1))#temp
+      batteryTemp2 = battery#temp + 1
+  trigger "equalityStructUpdate"
+    (batteryTemp1 == batteryTemp2)
+    [arg battery, arg batteryTemp1, arg batteryTemp2]
+
+main :: IO ()
+main = do
+  -- Run the specification using the Copilot interpreter.
+  interpret 1 spec
+
+  -- Compile the specification to C.
+  spec' <- reify spec
+  compile "structs" spec'

--- a/copilot/examples/what4/Structs.hs
+++ b/copilot/examples/what4/Structs.hs
@@ -24,6 +24,11 @@ instance Struct Volts where
   toValues volts = [ Value Word16 (numVolts volts)
                    , Value Bool   (flag volts)
                    ]
+  -- Note that we do not implement `updateField` here. `updateField` is only
+  -- needed to make updates to structs work in the Copilot interpreter, and we
+  -- do not use the interpreter in this example. (See
+  -- `examples/StructsUpdateField.hs` for an example that does implement
+  -- `updateField`.)
 
 -- | `Volts` instance for `Typed`.
 instance Typed Volts where
@@ -42,6 +47,8 @@ instance Struct Battery where
                      , Value typeOf (volts battery)
                      , Value typeOf (other battery)
                      ]
+  -- Note that we do not implement `updateField` here for the same reasons as in
+  -- the `Struct Volts` instance above.
 
 -- | `Battery` instance for `Typed`. Note that `undefined` is used as an
 -- argument to `Field`. This argument is never used, so `undefined` will never


### PR DESCRIPTION
This adds an `examples/StructsUpdateField.hs` example that (1) describes how to implement `updateField` for some example `Struct` instances, and (2) demonstrates that `updateField` works by using it with the Copilot interpreter. This also adds Haddocks to `updateField` that briefly describes how one might implement `updateField` in custom `Struct` instances. Because the full details of implementing `updateField` are somewhat intricate, these Haddocks refer to the `copilot/examples/StructsUpdateField.hs` example for further information.

Fixes #525.