### PR TITLE
`copilot`: Add installation instructions for Fedora 40 and up. Refs #542.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,9 +1,10 @@
-2024-10-19
+2024-10-22
         * Update contribution guidelines. (#476)
         * Update README with missing publications. (#544)
         * Make the what4-propositional example's comments match results. (#535)
         * Add example describing how to implement updateField. (#525)
         * Standardize changelog format. (#550)
+        * Add installation instructions for Fedora 40 and up. (#542)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -76,6 +76,25 @@ It should end with a line like the following and not print any error messages:
 ghci> ghci> Leaving GHCi.
 ```
 
+### Fedora 40
+
+On Fedora 40 or newer, Copilot can be installed directly from the package
+repositories with:
+
+```sh
+$ sudo dnf install ghc-copilot-devel
+```
+
+To test that Copilot is available, execute the following:
+```sh
+$ ghci <<< 'import Language.Copilot'
+```
+
+It should end with a line like the following and not print any error messages:
+```sh
+ghci> ghci> Leaving GHCi.
+```
+
 ### Other Linux distributions
 
 On other Linux distributions or older Debian-based distributions, to use


### PR DESCRIPTION
Since September 2024, Copilot is available in Fedora 40 and newer. This commit adds installation instruction for Fedora.

Closes #542.