### PR TITLE
Standardize changelog format. Refs #550.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -18,7 +18,7 @@
 2024-01-07
         * Version bump (3.18). (#487)
         * Change return type of main generated for tests. (#468)
-        * Print constants in tests using portable suffixes. (#471).
+        * Print constants in tests using portable suffixes. (#471)
         * Pass output arrays as arguments to trigger argument functions. (#431)
         * Compliance with MISRA C 2023 / MISRA C 2012. (#472)
 
@@ -112,30 +112,30 @@
 
 2020-12-06
         * Version bump (3.2).
-        * Implemented arrays in test driver (#176).
-        * Fixed nested array initialisation bug (#173).
-        * Fixed length of buffer allocation for n-dimensional arrays (#174).
-        * Fixed printing of long ints in test suite (#177).
-        * Fixed printing of unsigned ints in test suite (#177).
-        * Fixed '-Wsequence-point' warnings from GCC (#179).
-        * Split Property.hs (#180).
-        * Removed 'Test' from module paths (#181).
-        * Made compiletest take compiler options as an argument (#182).
-        * Fixed problem with property and empty string in driver CSV (#183).
-        * Added comma to output of driver to match the interpreter (#184).
-        * Implemented basic quickcheck based testing (#185).
+        * Implemented arrays in test driver. (#176)
+        * Fixed nested array initialisation bug. (#173)
+        * Fixed length of buffer allocation for n-dimensional arrays. (#174)
+        * Fixed printing of long ints in test suite. (#177)
+        * Fixed printing of unsigned ints in test suite. (#177)
+        * Fixed '-Wsequence-point' warnings from GCC. (#179)
+        * Split Property.hs. (#180)
+        * Removed 'Test' from module paths. (#181)
+        * Made compiletest take compiler options as an argument. (#182)
+        * Fixed problem with property and empty string in driver CSV. (#183)
+        * Added comma to output of driver to match the interpreter. (#184)
+        * Implemented basic quickcheck based testing. (#185)
 
 2020-03-30
-        * Version bump (3.1.2)
+        * Version bump (3.1.2).
         * Fixed bug where stream buffers are updated too soon. (#188)
         * Updated description of cabal package. (#192)
 
 2019-12-23
         * Version bump (3.1.1).
-        * Fixed bug with constant structs and arrays.(#200).
+        * Fixed bug with constant structs and arrays. (#200)
 
 2019-11-22
         * Version bump (3.1).
-        * Remove ExternFun (#207).
-        * Fix bug in code generation for local expression (#198).
-        * Implement code generation for labels (trivially) (#199).
+        * Remove ExternFun. (#207)
+        * Fix bug in code generation for local expression. (#198)
+        * Implement code generation for labels (trivially). (#199)

--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -111,7 +111,7 @@
         * Completed the documentation. (#171)
 
 2020-12-06
-        * Version bump (3.2).
+        * Version bump (3.2). (#65)
         * Implemented arrays in test driver. (#176)
         * Fixed nested array initialisation bug. (#173)
         * Fixed length of buffer allocation for n-dimensional arrays. (#174)
@@ -126,16 +126,16 @@
         * Implemented basic quickcheck based testing. (#185)
 
 2020-03-30
-        * Version bump (3.1.2).
+        * Version bump (3.1.2). (#187)
         * Fixed bug where stream buffers are updated too soon. (#188)
         * Updated description of cabal package. (#192)
 
 2019-12-23
-        * Version bump (3.1.1).
+        * Version bump (3.1.1). (#191)
         * Fixed bug with constant structs and arrays. (#200)
 
 2019-11-22
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)
         * Remove ExternFun. (#207)
         * Fix bug in code generation for local expression. (#198)
         * Implement code generation for labels (trivially). (#199)

--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-19
+        * Standardize changelog format. (#550)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Add support for array updates. (#36)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -140,14 +140,14 @@
         * Completed the documentation. (#145)
 
 2020-12-06 Ivan Perez <ivan.perez@acm.org>
-        * Version bump (3.2).
+        * Version bump (3.2). (#65)
         * Fixed implementation of tysize for n-dimensional arrays. (#147)
         * Removed sorting of interpreter output. (#148)
         * Minor documentation fixes. (#149, #151)
         * Credits: @fdedden.
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)
         * Eliminate random modules and generators. (#157)
         * Updated contact information for 'impossible' error. (#154)
         * Implement missing pretty printer for Index operator. (#155)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -141,13 +141,13 @@
 
 2020-12-06 Ivan Perez <ivan.perez@acm.org>
         * Version bump (3.2).
-        * Fixed implementation of tysize for n-dimensional arrays. (#147).
-        * Removed sorting of interpreter output (#148).
-        * Minor documentation fixes (#149, #151).
+        * Fixed implementation of tysize for n-dimensional arrays. (#147)
+        * Removed sorting of interpreter output. (#148)
+        * Minor documentation fixes. (#149, #151)
         * Credits: @fdedden.
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
         * Version bump (3.1).
-        * Eliminate random modules and generators (#157).
-        * Updated contact information for 'impossible' error (#154).
-        * Implement missing pretty printer for Index operator (#155).
+        * Eliminate random modules and generators. (#157)
+        * Updated contact information for 'impossible' error. (#154)
+        * Implement missing pretty printer for Index operator. (#155)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -139,14 +139,14 @@
         * Version bump (3.2.1). (#136)
         * Completed the documentation. (#145)
 
-2020-12-06 Ivan Perez <ivan.perez@acm.org>
+2020-12-06
         * Version bump (3.2). (#65)
         * Fixed implementation of tysize for n-dimensional arrays. (#147)
         * Removed sorting of interpreter output. (#148)
         * Minor documentation fixes. (#149, #151)
         * Credits: @fdedden.
 
-2019-11-22 Ivan Perez <ivan.perez@nianet.org>
+2019-11-22
         * Version bump (3.1). (#46)
         * Eliminate random modules and generators. (#157)
         * Updated contact information for 'impossible' error. (#154)

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,5 +1,6 @@
-2024-10-18
+2024-10-19
         * Add Haddocks for updateField. (#525)
+        * Standardize changelog format. (#550)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -117,6 +117,6 @@
           (#116)
         * Bump ghc-prim version bounds. (#122)
 
-2019-11-22 Ivan Perez <ivan.perez@nianet.org>
+2019-11-22
         * Version bump (3.1). (#46)
         * Remove ExternFun. (#118)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,5 +1,6 @@
-2024-10-15
+2024-10-19
         * Reject duplicate externs in properties and theorems. (#536)
+        * Standardize changelog format. (#550)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -111,12 +111,12 @@
         * Completed the documentation. (#112)
 
 2020-05-07
-        * Version bump (3.2).
+        * Version bump (3.2). (#65)
         * Fixed the reverse order of triggers. (#114)
         * Update description, bug-reports, changelog fields in cabal file.
           (#116)
         * Bump ghc-prim version bounds. (#122)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)
         * Remove ExternFun. (#118)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -112,11 +112,11 @@
 
 2020-05-07
         * Version bump (3.2).
-        * Fixed the reverse order of triggers (#114).
-        * Update description, bug-reports, changelog fields in cabal file
-          (#116).
-        * Bump ghc-prim version bounds (#122).
+        * Fixed the reverse order of triggers. (#114)
+        * Update description, bug-reports, changelog fields in cabal file.
+          (#116)
+        * Bump ghc-prim version bounds. (#122)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
         * Version bump (3.1).
-        * Remove ExternFun (#118).
+        * Remove ExternFun. (#118)

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -90,5 +90,5 @@
         * Version bump (3.2). (#65)
         * Update description, bug-reports, homepage fields in cabal file. (#129)
 
-2019-11-22 Ivan Perez <ivan.perez@nianet.org>
+2019-11-22
         * Version bump (3.1). (#46)

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-19
+        * Standardize changelog format. (#550)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Rename operator to avoid name clash. (#36)

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -87,8 +87,8 @@
         * Completed the documentation. (#127)
 
 2020-12-06
-        * Version bump (3.2).
+        * Version bump (3.2). (#65)
         * Update description, bug-reports, homepage fields in cabal file. (#129)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -88,7 +88,7 @@
 
 2020-12-06
         * Version bump (3.2).
-        * Update description, bug-reports, homepage fields in cabal file (#129).
+        * Update description, bug-reports, homepage fields in cabal file. (#129)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
         * Version bump (3.1).

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-19
+        * Standardize changelog format. (#550)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Add support for struct updates in Copilot.Theorem.What4. (#524)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -97,10 +97,10 @@
         * Completed the documentation. (#95, #93)
 
 2020-12-06
-        * Version bump (3.2).
+        * Version bump (3.2). (#65)
         * Update description, bug-reports and homepage field in cabal file.
           (#97)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)
         * Remove ExternFun. (#99)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -89,18 +89,18 @@
         * Version bump (3.4). (#231)
 
 2021-05-07
-        * Version bump (3.3). (#217).
-        * Adjust contraints on version of what4. (#90).
+        * Version bump (3.3). (#217)
+        * Adjust contraints on version of what4. (#90)
 
 2021-03-07
-        * Version bump (3.2.1). (#92).
-        * Completed the documentation. (#95, #93).
+        * Version bump (3.2.1). (#92)
+        * Completed the documentation. (#95, #93)
 
 2020-12-06
         * Version bump (3.2).
-        * Update description, bug-reports and homepage field in cabal file
-          (#97).
+        * Update description, bug-reports and homepage field in cabal file.
+          (#97)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
         * Version bump (3.1).
-        * Remove ExternFun (#99).
+        * Remove ExternFun. (#99)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -101,6 +101,6 @@
         * Update description, bug-reports and homepage field in cabal file.
           (#97)
 
-2019-11-22 Ivan Perez <ivan.perez@nianet.org>
+2019-11-22
         * Version bump (3.1). (#46)
         * Remove ExternFun. (#99)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,8 +1,9 @@
-2024-10-18
+2024-10-19
         * Update contribution guidelines. (#476)
         * Update README with missing publications. (#544)
         * Make the what4-propositional example's comments match results. (#535)
         * Add example describing how to implement updateField. (#525)
+        * Standardize changelog format. (#550)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -128,6 +128,6 @@
         * Update description in cabal file to match copilot-core. (#50)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
-        * Version bump (3.1).
+        * Version bump (3.1). (#46)
         * Update multiple examples. (#41)
         * Update instructions to match new repositry name. (#45)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -127,7 +127,7 @@
         * Add Ivan Perez as co-maintainer. (#51)
         * Update description in cabal file to match copilot-core. (#50)
 
-2019-11-22 Ivan Perez <ivan.perez@nianet.org>
+2019-11-22
         * Version bump (3.1). (#46)
         * Update multiple examples. (#41)
         * Update instructions to match new repositry name. (#45)

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,5 +1,5 @@
 2024-10-18
-        * Update contribution guidelines (#476).
+        * Update contribution guidelines. (#476)
         * Update README with missing publications. (#544)
         * Make the what4-propositional example's comments match results. (#535)
         * Add example describing how to implement updateField. (#525)
@@ -123,11 +123,11 @@
 
 2020-12-06
         * Update optparse-applicative dependency version for newer base
-          versions. (#61).
-        * Add Ivan Perez as co-maintainer (#51).
-        * Update description in cabal file to match copilot-core (#50).
+          versions. (#61)
+        * Add Ivan Perez as co-maintainer. (#51)
+        * Update description in cabal file to match copilot-core. (#50)
 
 2019-11-22 Ivan Perez <ivan.perez@nianet.org>
         * Version bump (3.1).
-        * Update multiple examples (#41).
-        * Update instructions to match new repositry name (#45).
+        * Update multiple examples. (#41)
+        * Update instructions to match new repositry name. (#45)


### PR DESCRIPTION
Standardize format of changelog entries, as prescribed in the solution proposed for #550.

This PR also standardizes the format of blocks, and adds missing issue numbers, to keep all blocks and entries reasonably regular.