### PR TITLE
`copilot-core`: Deprecate `Copilot.Core.Type.UType.uTypeType`. Refs #484.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,6 +1,7 @@
-2024-10-19
+2024-10-28
         * Add Haddocks for updateField. (#525)
         * Standardize changelog format. (#550)
+        * Deprecate Copilot.Core.Type.UType.uTypeType. (#484)
 
 2024-09-07
         * Version bump (4.0). (#532)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -268,6 +268,7 @@ instance (Typeable t, Typed t, KnownNat n) => Typed (Array n t) where
 
 -- | A untyped type (no phantom type).
 data UType = forall a . Typeable a => UType { uTypeType :: Type a }
+{-# DEPRECATED uTypeType "This field is deprecated in Copilot 4.1. Use pattern matching instead." #-}
 
 instance Eq UType where
   UType ty1 == UType ty2 = typeRep ty1 == typeRep ty2


### PR DESCRIPTION
Deprecate the record field `Copilot.Core.Type.UType.uTypeType`, as prescribed in the solution proposed for #484.