### PR TITLE
Release 4.1. Refs #561.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-19
+2024-11-07
+        * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)
 
 2024-09-07

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-c99
-version                   : 4.0
+version                   : 4.1
 synopsis                  : A compiler for Copilot targeting C99.
 description               :
   This package is a back-end from Copilot to C.
@@ -45,7 +45,7 @@ library
                           , mtl                 >= 2.2 && < 2.4
                           , pretty              >= 1.1 && < 1.2
 
-                          , copilot-core        >= 4.0   && < 4.1
+                          , copilot-core        >= 4.1   && < 4.2
                           , language-c99        >= 0.2.0 && < 0.3
                           , language-c99-simple >= 0.3   && < 0.4
 

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-28
+2024-11-07
+        * Version bump (4.1). (#561)
         * Add Haddocks for updateField. (#525)
         * Standardize changelog format. (#550)
         * Deprecate Copilot.Core.Type.UType.uTypeType. (#484)

--- a/copilot-core/copilot-core.cabal
+++ b/copilot-core/copilot-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-core
-version:             4.0
+version:             4.1
 synopsis:            An intermediate representation for Copilot.
 description:
   Intermediate representation for Copilot.

--- a/copilot-interpreter/CHANGELOG
+++ b/copilot-interpreter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-07
+        * Version bump (4.1). (#561)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Add support for array updates. (#36)

--- a/copilot-interpreter/copilot-interpreter.cabal
+++ b/copilot-interpreter/copilot-interpreter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-interpreter
-version:             4.0
+version:             4.1
 synopsis:            Interpreter for Copilot.
 description:
   Interpreter for Copilot.
@@ -44,7 +44,7 @@ library
     base       >= 4.9 && < 5,
     pretty     >= 1.0 && < 1.2,
 
-    copilot-core >= 4.0 && < 4.1
+    copilot-core >= 4.1 && < 4.2
 
   exposed-modules:
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-19
+2024-11-07
+        * Version bump (4.1). (#561)
         * Reject duplicate externs in properties and theorems. (#536)
         * Standardize changelog format. (#550)
 

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-language
-version:             4.0
+version:             4.1
 synopsis:            A Haskell-embedded DSL for monitoring hard real-time
                      distributed systems.
 description:
@@ -42,9 +42,9 @@ library
                , data-reify            >= 0.6  && < 0.7
                , mtl                   >= 2.0  && < 3
 
-               , copilot-core          >= 4.0 && < 4.1
-               , copilot-interpreter   >= 4.0 && < 4.1
-               , copilot-theorem       >= 4.0 && < 4.1
+               , copilot-core          >= 4.1 && < 4.2
+               , copilot-interpreter   >= 4.1 && < 4.2
+               , copilot-theorem       >= 4.1 && < 4.2
 
   exposed-modules: Copilot.Language
                  , Copilot.Language.Operators.BitWise

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-19
+2024-11-07
+        * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)
 
 2024-09-07

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-libraries
-version:             4.0
+version:             4.1
 synopsis:            Libraries for the Copilot language.
 description:
   Libraries for the Copilot language.
@@ -41,7 +41,7 @@ library
                , containers       >= 0.4 && < 0.7
                , mtl              >= 2.0 && < 2.4
                , parsec           >= 2.0 && < 3.2
-               , copilot-language >= 4.0 && < 4.1
+               , copilot-language >= 4.1 && < 4.2
 
   exposed-modules:
       Copilot.Library.Libraries

--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-07
+        * Version bump (4.1). (#561)
+
 2024-09-07
         * Version bump (4.0). (#532)
         * Add support for pretty-printing struct update expressions. (#526)

--- a/copilot-prettyprinter/copilot-prettyprinter.cabal
+++ b/copilot-prettyprinter/copilot-prettyprinter.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                copilot-prettyprinter
-version:             4.0
+version:             4.1
 synopsis:            A prettyprinter of Copilot Specifications.
 description:
   A prettyprinter of Copilot specifications.
@@ -45,7 +45,7 @@ library
     base   >= 4.9 && < 5,
     pretty >= 1.0 && < 1.2,
 
-    copilot-core >= 4.0 && < 4.1
+    copilot-core >= 4.1 && < 4.2
 
   exposed-modules:
 

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-19
+2024-11-07
+        * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)
 
 2024-09-07

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -14,7 +14,7 @@ description:
   <https://copilot-language.github.io>.
 
 
-version                   : 4.0
+version                   : 4.1
 license                   : BSD3
 license-file              : LICENSE
 maintainer                : Ivan Perez <ivan.perezdominguez@nasa.gov>
@@ -63,8 +63,8 @@ library
                           , xml                   >= 1.3 && < 1.4
                           , what4                 >= 1.3 && < 1.7
 
-                          , copilot-core          >= 4.0 && < 4.1
-                          , copilot-prettyprinter >= 4.0 && < 4.1
+                          , copilot-core          >= 4.1 && < 4.2
+                          , copilot-prettyprinter >= 4.1 && < 4.2
 
   exposed-modules         : Copilot.Theorem
                           , Copilot.Theorem.Prove

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,4 +1,5 @@
-2024-10-22
+2024-11-07
+        * Version bump (4.1). (#561)
         * Update contribution guidelines. (#476)
         * Update README with missing publications. (#544)
         * Make the what4-propositional example's comments match results. (#535)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -1,5 +1,5 @@
 name:                copilot
-version:             4.0
+version:             4.1
 cabal-version:       >= 1.10
 license:             BSD3
 license-file:        LICENSE
@@ -52,12 +52,12 @@ library
                      , directory             >= 1.3  && < 1.4
                      , filepath              >= 1.4  && < 1.5
 
-                     , copilot-core          >= 4.0 && < 4.1
-                     , copilot-theorem       >= 4.0 && < 4.1
-                     , copilot-language      >= 4.0 && < 4.1
-                     , copilot-libraries     >= 4.0 && < 4.1
-                     , copilot-c99           >= 4.0 && < 4.1
-                     , copilot-prettyprinter >= 4.0 && < 4.1
+                     , copilot-core          >= 4.1 && < 4.2
+                     , copilot-theorem       >= 4.1 && < 4.2
+                     , copilot-language      >= 4.1 && < 4.2
+                     , copilot-libraries     >= 4.1 && < 4.2
+                     , copilot-c99           >= 4.1 && < 4.2
+                     , copilot-prettyprinter >= 4.1 && < 4.2
 
 
     exposed-modules: Language.Copilot, Language.Copilot.Main


### PR DESCRIPTION
This PR updates the version numbers of all packages, as well as the version bounds of all dependencies on Copilot, as prescribed in the solution proposed for #561.