### PR TITLE
`copilot-core`: Deprecate fields of record `Copilot.Core.Expr.UExpr`. Refs #565.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-14
+        * Remove uses of Copilot.Core.Expr.UExpr.uExprType. (#565)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)

--- a/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/CodeGen.hs
@@ -279,7 +279,7 @@ mkStep cSettings streams triggers exts =
         aTmpDeclns = zipWith declare args aTempNames
           where
             declare :: UExpr -> C.Ident -> C.Decln
-            declare (UExpr { uExprType = ty }) tmpVar =
+            declare (UExpr ty _) tmpVar =
               C.VarDecln Nothing (transType ty) tmpVar Nothing
 
         triggerCheckStmt :: C.Stmt
@@ -301,7 +301,7 @@ mkStep cSettings streams triggers exts =
                 argAssigns = zipWith3 assign aTempNames aArgNames args
 
                 assign :: C.Ident -> C.Ident -> UExpr -> C.Expr
-                assign aTempName aArgName (UExpr { uExprType = ty }) =
+                assign aTempName aArgName (UExpr ty _) =
                   updateVar aTempName aArgName ty
 
                 aArgNames :: [C.Ident]
@@ -314,7 +314,7 @@ mkStep cSettings streams triggers exts =
                 -- so we also need the type of the expression, which is enclosed
                 -- in the second argument, an UExpr.
                 passArg :: String -> UExpr -> C.Expr
-                passArg aTempName (UExpr { uExprType = ty }) =
+                passArg aTempName (UExpr ty _) =
                   case ty of
                     -- Special case for Struct to pass reference to temporary
                     -- struct variable to handler. (See the comments for

--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-15
+        * Deprecate fields of Copilot.Core.Expr.UExpr. (#565)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Add Haddocks for updateField. (#525)

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -71,3 +71,4 @@ data UExpr = forall a . Typeable a => UExpr
   { uExprType :: Type a
   , uExprExpr :: Expr a
   }
+{-# DEPRECATED uExprType, uExprExpr "These fields are deprecated in Copilot 4.2. Use pattern matching instead." #-}

--- a/copilot-prettyprinter/CHANGELOG
+++ b/copilot-prettyprinter/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-15
+        * Remove uses of Copilot.Core.Expr.UExpr.uExprExpr. (#565)
+
 2024-11-07
         * Version bump (4.1). (#561)
 

--- a/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
+++ b/copilot-prettyprinter/src/Copilot/PrettyPrint.hs
@@ -43,7 +43,7 @@ ppExpr e0 = case e0 of
 --
 -- The type is ignored, and only the expression is pretty-printed.
 ppUExpr :: UExpr -> Doc
-ppUExpr UExpr { uExprExpr = e0 } = ppExpr e0
+ppUExpr (UExpr _ e0) = ppExpr e0
 
 -- | Pretty-print a unary operation.
 ppOp1 :: Op1 a b -> Doc -> Doc

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-15
+        * Remove uses of Copilot.Core.Expr.UExpr.uExprType,uExprExpr. (#565)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -324,7 +324,7 @@ computeTriggerState sym spec = forM (CS.specTriggers spec) $
          args' <- mapM computeArg args
          return (nm, guard', args')
   where
-   computeArg (CE.UExpr { CE.uExprType = tp, CE.uExprExpr = ex }) = do
+   computeArg (CE.UExpr tp ex) = do
      v <- translateExpr sym mempty ex (RelativeOffset 0)
      return (Some tp, v)
 


### PR DESCRIPTION
Deprecate fields of record Copilot.Core.Expr.UExpr, and replace any uses of them, as prescribed in the solution proposed for #565.