### PR TITLE
`copilot-c99`: Allow multiple triggers with the same name. Refs #296.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,5 +1,6 @@
-2024-11-14
+2024-12-20
         * Remove uses of Copilot.Core.Expr.UExpr.uExprType. (#565)
+        * Allow using same trigger name in multiple declarations. (#296)
 
 2024-11-07
         * Version bump (4.1). (#561)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -59,6 +59,7 @@ library
                          , Copilot.Compile.C99.External
                          , Copilot.Compile.C99.Compile
                          , Copilot.Compile.C99.Settings
+                         , Copilot.Compile.C99.Representation
 
 test-suite unit-tests
   type:

--- a/copilot-c99/src/Copilot/Compile/C99/Representation.hs
+++ b/copilot-c99/src/Copilot/Compile/C99/Representation.hs
@@ -1,0 +1,21 @@
+-- | C99 backend specific versions of selected `Copilot.Core` datatypes.
+module Copilot.Compile.C99.Representation
+    ( UniqueTrigger (..)
+    , UniqueTriggerId
+    , mkUniqueTriggers
+    )
+  where
+
+import Copilot.Core ( Trigger (..) )
+
+-- | Internal unique name for a trigger.
+type UniqueTriggerId = String
+
+-- | A `Copilot.Core.Trigger` with an unique name.
+data UniqueTrigger = UniqueTrigger UniqueTriggerId Trigger
+
+-- | Given a list of triggers, make their names unique.
+mkUniqueTriggers :: [Trigger] -> [UniqueTrigger]
+mkUniqueTriggers ts = zipWith mkUnique ts [0..]
+  where
+    mkUnique t@(Trigger name _ _) n = UniqueTrigger (name ++ "_" ++ show n) t


### PR DESCRIPTION
Extends the C99 backend to allow multiple references to the same trigger:

```haskell
spec = do
  trigger "f" guard0 [arg $ constI8 10]
  trigger "f" guard1 [arg $ constI8 12]
```

Note that the guards may overlap, which will mean the trigger is called twice in that iteration.

As C99 does not allow multiple function definitions sharing the same name, we can only allow a single type per trigger function. The following is explicitly disallowed by the backend:

```haskell
spec = do
  trigger "f" guard0 [arg $ constI8 10]
  trigger "f" guard1 [arg $ constI8 12, arg $ constI8 15]
```

Upon compilation, the user gets an error message:
```
Copilot error: attempt at compiling specification with conflicting trigger definitions.
Multiple triggers have the same name, but different argument types.
```

Feel free to make any modification necessary to my commits.