### PR TITLE
Bump version bounds on dependencies. Refs #570.

### DIFF
--- a/copilot-c99/CHANGELOG
+++ b/copilot-c99/CHANGELOG
@@ -1,6 +1,7 @@
-2024-12-20
+2025-01-02
         * Remove uses of Copilot.Core.Expr.UExpr.uExprType. (#565)
         * Allow using same trigger name in multiple declarations. (#296)
+        * Bump upper version constraint on filepath. (#570)
 
 2024-11-07
         * Version bump (4.1). (#561)

--- a/copilot-c99/copilot-c99.cabal
+++ b/copilot-c99/copilot-c99.cabal
@@ -41,7 +41,7 @@ library
   ghc-options             : -Wall
   build-depends           : base                >= 4.9 && < 5
                           , directory           >= 1.3 && < 1.4
-                          , filepath            >= 1.4 && < 1.5
+                          , filepath            >= 1.4 && < 1.6
                           , mtl                 >= 2.2 && < 2.4
                           , pretty              >= 1.1 && < 1.2
 

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-02
+        * Bump upper version constraint on containers. (#570)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Reject duplicate externs in properties and theorems. (#536)

--- a/copilot-language/copilot-language.cabal
+++ b/copilot-language/copilot-language.cabal
@@ -38,7 +38,7 @@ library
   build-depends: base                  >= 4.9  && < 5
 
                , array                 >= 0.5  && < 0.6
-               , containers            >= 0.4  && < 0.7
+               , containers            >= 0.4  && < 0.8
                , data-reify            >= 0.6  && < 0.7
                , mtl                   >= 2.0  && < 3
 

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-02
+        * Bump upper version constraint on containers. (#570)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Standardize changelog format. (#550)

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -38,7 +38,7 @@ library
 
   build-depends: base             >= 4.9 && < 5
 
-               , containers       >= 0.4 && < 0.7
+               , containers       >= 0.4 && < 0.8
                , mtl              >= 2.0 && < 2.4
                , parsec           >= 2.0 && < 3.2
                , copilot-language >= 4.1 && < 4.2

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,6 @@
-2024-11-15
+2025-01-02
         * Remove uses of Copilot.Core.Expr.UExpr.uExprType,uExprExpr. (#565)
+        * Bump upper constraint on containers, data-default. (#570)
 
 2024-11-07
         * Version bump (4.1). (#561)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -49,7 +49,7 @@ library
                           , bimap                 (>= 0.3 && < 0.4) || (>= 0.5 && < 0.6)
                           , bv-sized              >= 1.0.2 && < 1.1
                           , containers            >= 0.4 && < 0.8
-                          , data-default          >= 0.7 && < 0.8
+                          , data-default          >= 0.7 && < 0.9
                           , directory             >= 1.3 && < 1.4
                           , libBF                 >= 0.6.2 && < 0.7
                           , mtl                   >= 2.0 && < 2.4

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -48,7 +48,7 @@ library
   build-depends           : base                  >= 4.9 && < 5
                           , bimap                 (>= 0.3 && < 0.4) || (>= 0.5 && < 0.6)
                           , bv-sized              >= 1.0.2 && < 1.1
-                          , containers            >= 0.4 && < 0.7
+                          , containers            >= 0.4 && < 0.8
                           , data-default          >= 0.7 && < 0.8
                           , directory             >= 1.3 && < 1.4
                           , libBF                 >= 0.6.2 && < 0.7

--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-02
+        * Bump upper version constraint on filepath. (#570)
+
 2024-11-07
         * Version bump (4.1). (#561)
         * Update contribution guidelines. (#476)

--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -50,7 +50,7 @@ library
                        base                  >= 4.9  && < 5
                      , optparse-applicative  >= 0.14 && < 0.19
                      , directory             >= 1.3  && < 1.4
-                     , filepath              >= 1.4  && < 1.5
+                     , filepath              >= 1.4  && < 1.6
 
                      , copilot-core          >= 4.1 && < 4.2
                      , copilot-theorem       >= 4.1 && < 4.2


### PR DESCRIPTION
This commit bumps the version numbers for the upper bounds of constraints on dependencies, as prescribed in the solution to #570.

These changes allow for copilot to once again be included in GHC 9.10 Stackage Nightly.