### PR TITLE
Fix typos in documentation. Refs #587.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-28
+        * Fix typo in documentation. (#587)
+
 2025-01-07
         * Version bump (4.2). (#577)
         * Deprecate fields of Copilot.Core.Expr.UExpr. (#565)

--- a/copilot-core/src/Copilot/Core/Spec.hs
+++ b/copilot-core/src/Copilot/Core/Spec.hs
@@ -13,7 +13,7 @@
 --
 -- In order to be executed, high-level Copilot Language Spec must be turned
 -- into Copilot Core's 'Spec'. This module defines the low-level Copilot Core
--- representations for Specs and the main types of element in a spec..
+-- representations for Specs and the main types of element in a spec.
 module Copilot.Core.Spec
     ( Stream (..)
     , Observer (..)

--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-28
+        * Fix typo in documentation. (#587)
+
 2025-01-07
         * Version bump (4.2). (#577)
         * Bump upper version constraint on containers. (#570)

--- a/copilot-language/src/Copilot/Language/Operators/Projection.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Projection.hs
@@ -23,7 +23,7 @@ infixl 8 =$
 -- | Common interface to manipulate portions of a larger data structure.
 --
 -- A projectable d s t means that it is possible to manipulate a sub-element s
--- of type t carried in a stream of type d..
+-- of type t carried in a stream of type d.
 class Projectable d s t | d s -> t where
 
   -- | Unapplied projection or element access on a type.

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,6 @@
-2025-01-25
+2025-01-28
         * Fix multiple typos in README. (#560)
+        * Fix typo in documentation. (#587)
 
 2025-01-07
         * Version bump (4.2). (#577)

--- a/copilot-theorem/src/Copilot/Theorem/Misc/SExpr.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Misc/SExpr.hs
@@ -31,7 +31,7 @@ singleton a  = List [Atom a]        -- (s)
 list = List                 -- (ss)
 
 -- | Sequence of expressions with a root or main note, and a series of
--- additional expressions or arguments..
+-- additional expressions or arguments.
 node a l = List (Atom a : l)    -- (s ss)
 
 -- A straightforward string representation for 'SExpr's of Strings that


### PR DESCRIPTION
This commit fixes a recurrent typo in the documentation across three libraries, as prescribed in the solution proposed for #587.