### PR TITLE
`copilot`: Include missing dependencies in installation instructions. Refs #591.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-30
+        * Include missing dependencies in installation instructions. (#591)
+
 2025-01-07
         * Version bump (4.2). (#577)
         * Bump upper version constraint on filepath. (#570)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -102,10 +102,10 @@ Copilot you must install a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
 (9.8 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/) or, if you are on Debian/Ubuntu,
-directly with `apt-get`:
+you can use `apt-get` to install all dependencies as follows:
 
 ```sh
-$ sudo apt-get install ghc cabal-install
+$ sudo apt-get install ghc cabal-install alex happy pkg-config libz-dev
 ```
 
 Once the compiler is installed, install Copilot from


### PR DESCRIPTION
Adjust the installation instructions for Linux distributions where Copilot is not directly available as a package to include other dependencies needed, as prescribed in the solution proposed for #591.