### PR TITLE
`copilot`: Document changes in CHANGELOG. Refs #590.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,5 +1,6 @@
-2025-01-30
+2025-01-31
         * Include missing dependencies in installation instructions. (#591)
+        * Update version of GHC in README. (#590)
 
 2025-01-07
         * Version bump (4.2). (#577)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -100,7 +100,7 @@ ghci> ghci> Leaving GHCi.
 On other Linux distributions or older Debian-based distributions, to use
 Copilot you must install a Haskell compiler (GHC) and the package manager
 Cabal. We currently support all versions of GHC from 8.6.5 to modern versions
-(9.8 as of this writing). You can install the toolchain using
+(9.10 as of this writing). You can install the toolchain using
 [ghcup](https://www.haskell.org/ghcup/) or, if you are on Debian/Ubuntu,
 you can use `apt-get` to install all dependencies as follows:
 


### PR DESCRIPTION
Update the installation instructions to reflect that Copilot is compatible with versions of GHC 9.10 as of this writing, as prescribed in the solution proposed for #590.