### PR TITLE
`copilot`: List all Copilot packages in installation command in README. Refs #597.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,7 +1,8 @@
-2025-02-24
+2025-03-05
         * Include missing dependencies in installation instructions. (#591)
         * Update version of GHC in README. (#590)
         * Add example of how to use proveWithCounterExample. (#589)
+        * List all Copilot packages in installation command in README. (#597)
 
 2025-01-07
         * Version bump (4.2). (#577)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -112,7 +112,8 @@ Once the compiler is installed, install Copilot from
 [Hackage](https://hackage.haskell.org/package/copilot) with:
 
 ```sh
-cabal v2-install --lib copilot
+cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
 ```
 
 To test that Copilot is available, execute the following:
@@ -141,7 +142,8 @@ Once the compiler is installed, install Copilot from
 [Hackage](https://hackage.haskell.org/package/copilot) with:
 
 ```sh
-$ cabal v2-install --lib copilot
+$ cabal v2-install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
 ```
 
 To test that Copilot is available, execute the following:


### PR DESCRIPTION
List all Copilot packages as arguments to `cabal v2-install --lib` in the manual installation sections of the README, as prescribed in the solution proposed for #597.