### PR TITLE
Remove deprecated functions `(.!!)` and `(!!)`. Refs #599.

### DIFF
--- a/copilot-language/CHANGELOG
+++ b/copilot-language/CHANGELOG
@@ -1,6 +1,8 @@
-2025-02-28
+2025-03-07
         * Fix typo in documentation. (#587)
         * Record how a Property's underlying proposition is quantified. (#254)
+        * Remove deprecated function Copilot.Language.Operators.Array.(.!!).
+          (#599)
 
 2025-01-07
         * Version bump (4.2). (#577)

--- a/copilot-language/src/Copilot/Language/Operators/Array.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Array.hs
@@ -8,8 +8,7 @@
 
 -- | Combinators to deal with streams carrying arrays.
 module Copilot.Language.Operators.Array
-  ( (.!!)
-  , (!)
+  ( (!)
   , (!!)
   , (=:)
   , (=$)
@@ -33,18 +32,6 @@ import Prelude      hiding ((!!))
 (!) :: (KnownNat n, Typed t)
     => Stream (Array n t) -> Stream Word32 -> Stream t
 arr ! n = Op2 (Index typeOf) arr n
-
--- | Create a stream that carries an element of an array in another stream.
---
--- This function implements a projection of the element of an array at a given
--- position, over time. For example, if @s@ is a stream of type @Stream (Array
--- '5 Word8)@, then @s .!! 3@ has type @Stream Word8@ and contains the 3rd
--- element (starting from zero) of the arrays in @s@ at any point in time.
-{-# DEPRECATED (.!!) "This function is deprecated in Copilot 4. Use (!)." #-}
-(.!!) :: ( KnownNat n
-         , Typed t
-         ) => Stream (Array n t) -> Stream Word32 -> Stream t
-(.!!) = (!)
 
 -- | Pair a stream with an element accessor, without applying it to obtain the
 -- value of the element.

--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2025-03-07
+        * Remove deprecated function Copilot.Library.Utils.(!!). (#599)
+
 2025-01-07
         * Version bump (4.2). (#577)
         * Bump upper version constraint on containers. (#570)

--- a/copilot-libraries/src/Copilot/Library/Libraries.hs
+++ b/copilot-libraries/src/Copilot/Library/Libraries.hs
@@ -23,6 +23,6 @@ import Copilot.Library.LTL
 import Copilot.Library.PTLTL
 import Copilot.Library.Statistics
 import Copilot.Library.RegExp
-import Copilot.Library.Utils      hiding ((!!))
+import Copilot.Library.Utils
 import Copilot.Library.Voting
 import Copilot.Library.Stacks

--- a/copilot-libraries/src/Copilot/Library/Utils.hs
+++ b/copilot-libraries/src/Copilot/Library/Utils.hs
@@ -13,10 +13,10 @@ module Copilot.Library.Utils
          -- ** Scans
          nscanl, nscanr, nscanl1, nscanr1,
          -- ** Indexing
-         case', (!!), (!!!))
+         case', (!!!))
 where
 
-import Copilot.Language hiding ((!!))
+import Copilot.Language
 import qualified Prelude as P
 
 -- | Given a stream, produce an infinite list of streams dropping an increasing
@@ -130,13 +130,6 @@ case' predicates alternatives =
                    P.++ "length of alternatives list is not "
                    P.++ "greater by one than the length of predicates list"
   in case'' predicates alternatives
-
--- | Index.
---
--- WARNING: Very expensive! Consider using this only for very short lists.
-(!!) :: (Typed a, Eq b, Num b, Typed b) => [Stream a] -> Stream b -> Stream a
-(!!) = (!!!)
-{-# DEPRECATED (!!) "This function is deprecated in Copilot 4. Use (!!!)." #-}
 
 -- | Index.
 --


### PR DESCRIPTION
Remove the deprecated functions `copilot-language:Copilot.Language.Operators.Array.(.!!)` and `copilot-libraries:Copilot.Library.Utils.(!!)`, as prescribed in the solution proposed for #599.