### PR TITLE
Allow appending and then dropping the same number of elements from Stream

### DIFF
--- a/copilot-language/src/Copilot/Language/Analyze.hs
+++ b/copilot-language/src/Copilot/Language/Analyze.hs
@@ -188,7 +188,7 @@ analyzeAppend refStreams dstn e b f = do
 -- append.
 analyzeDrop :: Int -> Stream a -> IO ()
 analyzeDrop k (Append xs _ _)
-  | k >= length xs                         = throw DropIndexOverflow
+  | k > length xs                          = throw DropIndexOverflow
   | k > fromIntegral (maxBound :: DropIdx) = throw DropMaxViolation
   | otherwise                              = return ()
 analyzeDrop _ _                            = throw DropAppliedToNonAppend

--- a/copilot-language/src/Copilot/Language/Operators/Temporal.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Temporal.hs
@@ -1,5 +1,4 @@
 -- Copyright © 2011 National Institute of Aerospace / Galois, Inc.
-
 {-# LANGUAGE Safe #-}
 
 -- | Temporal stream transformations.
@@ -11,7 +10,7 @@ module Copilot.Language.Operators.Temporal
 import Copilot.Core (Typed)
 import Copilot.Language.Prelude
 import Copilot.Language.Stream
-import Prelude ()
+import Prelude ((==))
 
 infixr 1 ++
 
@@ -32,8 +31,11 @@ infixr 1 ++
 -- elements. For most kinds of streams, you cannot drop elements without
 -- prepending an equal or greater number of elements to them first, as it
 -- could result in undefined samples.
-drop :: Typed a => Int -> Stream a -> Stream a
-drop 0 s             = s
-drop _ ( Const j )   = Const j
-drop i ( Drop  j s ) = Drop (fromIntegral i + j) s
-drop i s             = Drop (fromIntegral i)     s
+drop :: (Typed a) => Int -> Stream a -> Stream a
+drop 0 s = s
+-- Along with simplifying the Stream, this also avoids the invalid C code
+-- generated from append (array) and drop (indexing) when their lengths are the same
+drop i (Append a _ s) | i == length a = s
+drop _ (Const j) = Const j
+drop i (Drop j s) = Drop (fromIntegral i + j) s
+drop i s = Drop (fromIntegral i) s

--- a/copilot-language/src/Copilot/Language/Operators/Temporal.hs
+++ b/copilot-language/src/Copilot/Language/Operators/Temporal.hs
@@ -32,10 +32,10 @@ infixr 1 ++
 -- prepending an equal or greater number of elements to them first, as it
 -- could result in undefined samples.
 drop :: (Typed a) => Int -> Stream a -> Stream a
-drop 0 s = s
+drop 0 s                                = s
 -- Along with simplifying the Stream, this also avoids the invalid C code
 -- generated from append (array) and drop (indexing) when their lengths are the same
-drop i (Append a _ s) | i == length a = s
-drop _ (Const j) = Const j
-drop i (Drop j s) = Drop (fromIntegral i + j) s
-drop i s = Drop (fromIntegral i) s
+drop i ( Append a _ s ) | i == length a = s
+drop _ ( Const j )                      = Const j
+drop i ( Drop  j s )                    = Drop (fromIntegral i + j) s
+drop i s                                = Drop (fromIntegral i)     s

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -147,12 +147,9 @@ mkExpr refMkId refStreams refMap = go
     ------------------------------------------------------
 
     Drop k e1 -> case e1 of
-      Append a _ s ->
-        if k == length a
-        then go s
-        else do
-          _s <- mkStream refMkId refStreams refMap e1
-          return $ Core.Drop typeOf (fromIntegral k) _s
+      Append _ _ _ -> do
+        s <- mkStream refMkId refStreams refMap e1
+        return $ Core.Drop typeOf (fromIntegral k) s
       _ -> impossible "mkExpr" "copilot-language"
 
     ------------------------------------------------------

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -148,8 +148,8 @@ mkExpr refMkId refStreams refMap = go
 
     Drop k e1 -> case e1 of
       Append _ _ _ -> do
-        s <- mkStream refMkId refStreams refMap e1
-        return $ Core.Drop typeOf (fromIntegral k) s
+          s <- mkStream refMkId refStreams refMap e1
+          return $ Core.Drop typeOf (fromIntegral k) s
       _ -> impossible "mkExpr" "copilot-language"
 
     ------------------------------------------------------

--- a/copilot-language/src/Copilot/Language/Reify.hs
+++ b/copilot-language/src/Copilot/Language/Reify.hs
@@ -147,9 +147,12 @@ mkExpr refMkId refStreams refMap = go
     ------------------------------------------------------
 
     Drop k e1 -> case e1 of
-      Append _ _ _ -> do
-          s <- mkStream refMkId refStreams refMap e1
-          return $ Core.Drop typeOf (fromIntegral k) s
+      Append a _ s ->
+        if k == length a
+        then go s
+        else do
+          _s <- mkStream refMkId refStreams refMap e1
+          return $ Core.Drop typeOf (fromIntegral k) _s
       _ -> impossible "mkExpr" "copilot-language"
 
     ------------------------------------------------------


### PR DESCRIPTION
https://hackage.haskell.org/package/copilot-language-4.3/docs/Copilot-Language-Operators-Temporal.html#v:drop
> The elements must be realizable at the present time to be able to drop elements. For most kinds of streams, you cannot drop elements without prepending an **equal or** greater number of elements to them first, as it could result in undefined samples.

Current specification states that one may drop the elements from the stream as long as you have appended at least the same number of elements. But the current implementation throws `DropIndexOverflow` when you try to drop as many elements as appended.

By modifying `analyzeDrop` we can avoid exception, but copilot would emit incorrect C code from `Drop k (Append k s)`.
This is because `Append k s` emits an array of length k, but `Drop k s` gets converted to index k access, which becomes incorrect when drop length and append length are the same.
So I also modified the Reify module s.t. `Drop k (Append k s)` can be simplified to `s`. This way we can achieve both correct C codegen & reduced constructor chain.

This modification has been verified using `copilot-verifier` using several homegrown test cases.