### PR TITLE
`copilot-theorem`: Bump version bounds on `what4`. Refs #611.

### DIFF
--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -61,7 +61,7 @@ library
                           , random                >= 1.1 && < 1.3
                           , transformers          >= 0.5 && < 0.7
                           , xml                   >= 1.3 && < 1.4
-                          , what4                 >= 1.3 && < 1.7
+                          , what4                 >= 1.3 && < 1.8
 
                           , copilot-core          >= 4.3 && < 4.4
                           , copilot-prettyprinter >= 4.3 && < 4.4


### PR DESCRIPTION
## description

should close https://github.com/commercialhaskell/stackage/issues/7725; tested locally that this compiles as expected (although I haven't run the test suite yet to verify that they all pass).