### PR TITLE
`copilot-core`: Remove deprecated `Copilot.Core.Type.uTypeType`. Refs #615.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2025-04-21
+        * Remove deprecated Copilot.Core.Type.uTypeType. (#615)
+
 2025-03-07
         * Version bump (4.3). (#604)
         * Fix typo in documentation. (#587)

--- a/copilot-core/src/Copilot/Core/Type.hs
+++ b/copilot-core/src/Copilot/Core/Type.hs
@@ -289,8 +289,7 @@ instance (Typeable t, Typed t, KnownNat n) => Typed (Array n t) where
   simpleType (Array t) = SArray t
 
 -- | A untyped type (no phantom type).
-data UType = forall a . Typeable a => UType { uTypeType :: Type a }
-{-# DEPRECATED uTypeType "This field is deprecated in Copilot 4.1. Use pattern matching instead." #-}
+data UType = forall a . Typeable a => UType (Type a)
 
 instance Eq UType where
   UType ty1 == UType ty2 = typeRep ty1 == typeRep ty2


### PR DESCRIPTION
Remove the deprecated record field `uTypeType` from the definition of  `Copilot.Core.Type.UType`, as prescribed in the solution proposed for #615.