### PR TITLE
copilot: Update build status URL. Refs #612.

### DIFF
--- a/copilot/CHANGELOG
+++ b/copilot/CHANGELOG
@@ -1,3 +1,6 @@
+2025-04-18
+        * Update build status badge URL. (#612)
+
 2025-03-07
         * Version bump (4.3). (#604)
         * Include missing dependencies in installation instructions. (#591)

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -2,7 +2,7 @@
 
 # Copilot
 
-[![Build Status](https://travis-ci.com/Copilot-Language/copilot.svg?branch=master)](https://app.travis-ci.com/github/Copilot-Language/copilot)
+[![Build Status](https://api.travis-ci.com/Copilot-Language/copilot.svg?branch=master)](https://app.travis-ci.com/github/Copilot-Language/copilot)
 [![Version on Hackage](https://img.shields.io/hackage/v/copilot.svg)](https://hackage.haskell.org/package/copilot)
 
 Copilot is a runtime verification framework for hard real-time systems.


### PR DESCRIPTION
Currently the badge for the build status in the README doesn't show up
correctly. GitHub has cached the result but it's not providing the
resulting image, so we see "Build Status" instead.

This commit updates the badge URL to the current
"https://api.travis-ci.com/Copilot-Language/copilot.svg?branch=master",
which enables the badge to show properly.