### PR TITLE
`copilot-theorem`: Remove unused pragmas. Refs #613.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,12 +1,6 @@
 2025-05-29
-        * Version bump (4.4.1). (#613)
-        * Removed unused pragma: GeneralizedNewtypeDeriving from 'What4.hs' (#613)
-        * Removed unused pragma: MultiWayIf from 'What4.hs'  (#613)
-        * Removed unused pragma: StandaloneDeriving from 'What4.hs'  (#613)
-        * Removed unused pragma: TemplateHaskell from 'What4.hs'  (#613)
-        * Removed unused pragma: TupleSections from 'What4.hs'  (#613)
-        * Removed unused pragma: LambdaCase from 'Prover.hs' (#613)
-        * Removed unused pragma: LambdaCase from 'SMTIO.hs' (#613)
+        * Removed unused pragma. (#613)
+
 2025-05-07
         * Version bump (4.4). (#618)
         * Translate quantifiers correctly in Kind2 backend. (#594)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,5 @@
 2025-05-29
-        * Removed unused pragma. (#613)
+        * Removed unused pragmas. (#613)
 
 2025-05-07
         * Version bump (4.4). (#618)

--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,12 @@
+2025-05-29
+        * Version bump (4.4.1). (#613)
+        * Removed unused pragma: GeneralizedNewtypeDeriving from 'What4.hs' (#613)
+        * Removed unused pragma: MultiWayIf from 'What4.hs'  (#613)
+        * Removed unused pragma: StandaloneDeriving from 'What4.hs'  (#613)
+        * Removed unused pragma: TemplateHaskell from 'What4.hs'  (#613)
+        * Removed unused pragma: TupleSections from 'What4.hs'  (#613)
+        * Removed unused pragma: LambdaCase from 'Prover.hs' (#613)
+        * Removed unused pragma: LambdaCase from 'SMTIO.hs' (#613)
 2025-05-07
         * Version bump (4.4). (#618)
         * Translate quantifiers correctly in Kind2 backend. (#594)

--- a/copilot-theorem/src/Copilot/Theorem/Kind2/Prover.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Kind2/Prover.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase  #-}
 {-# LANGUAGE Trustworthy #-}
 
 -- | A prover backend based on Kind2.

--- a/copilot-theorem/src/Copilot/Theorem/Prover/SMTIO.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Prover/SMTIO.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes     #-}
 {-# LANGUAGE Safe           #-}

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiWayIf                 #-}

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeOperators              #-}
 

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeOperators              #-}

--- a/copilot-theorem/src/Copilot/Theorem/What4.hs
+++ b/copilot-theorem/src/Copilot/Theorem/What4.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE MultiWayIf                 #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}


### PR DESCRIPTION
Remove unused pragmas from `copilot-theorem` and update the changed logs, as as prescribed in the solution proposed for #613.
