### PR TITLE
`copilot-core`: Remove deprecated fields of `Copilot.Core.Expr.UExpr`. Refs #636.

### DIFF
--- a/copilot-core/CHANGELOG
+++ b/copilot-core/CHANGELOG
@@ -1,3 +1,6 @@
+2025-06-28
+        * Remove deprecated fields of Copilot.Core.Expr.UExpr. (#636)
+
 2025-05-07
         * Version bump (4.4). (#618)
         * Remove deprecated Copilot.Core.Type.uTypeType. (#615)

--- a/copilot-core/src/Copilot/Core/Expr.hs
+++ b/copilot-core/src/Copilot/Core/Expr.hs
@@ -67,8 +67,4 @@ data Expr a where
 -- | A untyped expression that carries the information about the type of the
 -- expression as a value, as opposed to exposing it at type level (using an
 -- existential).
-data UExpr = forall a . Typeable a => UExpr
-  { uExprType :: Type a
-  , uExprExpr :: Expr a
-  }
-{-# DEPRECATED uExprType, uExprExpr "These fields are deprecated in Copilot 4.2. Use pattern matching instead." #-}
+data UExpr = forall a . Typeable a => UExpr (Type a) (Expr a)


### PR DESCRIPTION
Remove the deprecated fields of the type `Copilot.Core.Expr.UExpr`, as prescribed in the solution proposed for #636.