### PR TITLE
`copilot-theorem`: Relax version constraint on `what4`. Refs #611.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,5 +1,6 @@
-2025-05-29
+2025-07-05
         * Removed unused pragmas. (#613)
+        * Relax version constraint on what4. (#611)
 
 2025-05-07
         * Version bump (4.4). (#618)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -61,7 +61,7 @@ library
                           , random                >= 1.1 && < 1.3
                           , transformers          >= 0.5 && < 0.7
                           , xml                   >= 1.3 && < 1.4
-                          , what4                 >= 1.3 && < 1.7
+                          , what4                 >= 1.3 && < 1.8
 
                           , copilot-core          >= 4.4 && < 4.5
                           , copilot-prettyprinter >= 4.4 && < 4.5


### PR DESCRIPTION
Relax version constraint on `what4` to allow installation with `what4-1.7`, as prescribed in the solution proposed for #611 .