### PR TITLE
`copilot-theorem`: Remove unused function `Copilot.Theorem.Misc.SExpr.parseSExpr`. Refs #661.

### DIFF
--- a/copilot-theorem/CHANGELOG
+++ b/copilot-theorem/CHANGELOG
@@ -1,3 +1,6 @@
+2025-09-07
+        * Remove unused function Copilot.Theorem.Misc.SExpr.parseSExpr. (#661)
+
 2025-07-07
         * Version bump (4.5). (#642)
         * Removed unused pragmas. (#613)

--- a/copilot-theorem/copilot-theorem.cabal
+++ b/copilot-theorem/copilot-theorem.cabal
@@ -54,7 +54,6 @@ library
                           , libBF                 >= 0.6.2 && < 0.7
                           , mtl                   >= 2.0 && < 2.4
                           , panic                 >= 0.4.0 && < 0.5
-                          , parsec                >= 2.0 && < 3.2
                           , parameterized-utils   >= 2.1.1 && < 2.2
                           , pretty                >= 1.0 && < 1.2
                           , process               >= 1.6 && < 1.7

--- a/copilot-theorem/src/Copilot/Theorem/Misc/SExpr.hs
+++ b/copilot-theorem/src/Copilot/Theorem/Misc/SExpr.hs
@@ -2,10 +2,9 @@
 {-# LANGUAGE Safe              #-}
 
 -- | A representation for structured expression trees, with support for pretty
--- printing and for parsing.
+-- printing.
 module Copilot.Theorem.Misc.SExpr where
 
-import Text.ParserCombinators.Parsec
 import Text.PrettyPrint.HughesPJ as PP hiding (char, Str)
 
 import Control.Monad
@@ -70,37 +69,3 @@ toDoc shouldIndent printAtom expr = case expr of
         doc $$ indent (toDoc shouldIndent printAtom s)
       | otherwise =
         doc <+> toDoc shouldIndent printAtom s
-
--- | Parser for strings of characters separated by spaces into a structured
--- tree.
---
--- Parentheses are interpreted as grouping elements, that is, defining a
--- 'List', which may be empty.
-parser :: GenParser Char st (SExpr String)
-parser =
-  choice [try unitP, nodeP, leafP]
-
-  where
-    symbol     = oneOf "!#$%&|*+-/:<=>?@^_~."
-    lonelyStr  = many1 (alphaNum <|> symbol)
-
-    unitP      = string "()" >> return unit
-
-    leafP      = atom <$> lonelyStr
-
-    nodeP      = do void $ char '('
-                    spaces
-                    st <- sepBy parser spaces
-                    spaces
-                    void $ char ')'
-                    return $ List st
-
--- | Parser for strings of characters separated by spaces into a structured
--- tree.
---
--- Parentheses are interpreted as grouping elements, that is, defining a
--- 'List', which may be empty.
-parseSExpr :: String -> Maybe (SExpr String)
-parseSExpr str = case parse parser "" str of
-  Left s -> error (show s) -- Nothing
-  Right t -> Just t


### PR DESCRIPTION
Remove the function `Copilot.Theorem.Misc.SExpr.parseSExpr` due to being unused, as well as other auxiliary definitions only used by that function, and any imports or dependencies in the Cabal file no longer necessary after that removal, as prescribed in the solution proposed for #661.