### PR TITLE
`copilot-libraries`: Add stream analysis module. Refs #726.

### DIFF
--- a/copilot-libraries/CHANGELOG
+++ b/copilot-libraries/CHANGELOG
@@ -1,3 +1,6 @@
+2026-05-07
+        * Add stream analysis module. (#726)
+
 2026-03-07
         * Version bump (4.7). (#714)
 

--- a/copilot-libraries/copilot-libraries.cabal
+++ b/copilot-libraries/copilot-libraries.cabal
@@ -44,7 +44,8 @@ library
                , copilot-language >= 4.7 && < 4.8
 
   exposed-modules:
-      Copilot.Library.Libraries
+      Copilot.Library.Analysis
+    , Copilot.Library.Libraries
     , Copilot.Library.Clocks
     , Copilot.Library.LTL
     , Copilot.Library.PTLTL

--- a/copilot-libraries/src/Copilot/Library/Analysis.hs
+++ b/copilot-libraries/src/Copilot/Library/Analysis.hs
@@ -1,0 +1,23 @@
+-- | Formally analyze streams.
+module Copilot.Library.Analysis
+    ( triviallyTrue
+    , triviallyFalse
+    )
+  where
+
+-- External imports.
+import Prelude hiding (not)
+
+-- Internal imports.
+import Copilot.Language      (Stream, forAll, not)
+import Copilot.Language.Spec (Prop, Universal)
+
+-- | Property that captures whether a stream is trivially true, meaning that
+-- there is no way to make it false.
+triviallyTrue :: Stream Bool -> Prop Universal
+triviallyTrue = forAll
+
+-- | Property that captures whether a stream is trivially false, meaning that
+-- there is no way to make it true.
+triviallyFalse :: Stream Bool -> Prop Universal
+triviallyFalse = triviallyTrue . not


### PR DESCRIPTION
Add module that provides basic stream analysis functions, as prescribed in the solution proposed for #726.