### PR TITLE
copilot: Add missing `base` and `containers` bounds. Refs #735.

### DIFF
--- a/copilot/copilot.cabal
+++ b/copilot/copilot.cabal
@@ -65,7 +65,7 @@ library
 executable what4-propositional
     main-is:                Propositional.hs
     hs-source-dirs:         examples/what4
-    build-depends:          base
+    build-depends:          base            >= 4.9  && < 5
                           , copilot
                           , copilot-theorem
     default-language:       Haskell2010
@@ -77,7 +77,7 @@ executable what4-propositional
 executable what4-arithmetic
     main-is:                Arithmetic.hs
     hs-source-dirs:         examples/what4
-    build-depends:          base
+    build-depends:          base            >= 4.9  && < 5
                           , copilot
                           , copilot-theorem
     default-language:       Haskell2010
@@ -89,8 +89,8 @@ executable what4-arithmetic
 executable what4-arithmetic-counterexamples
     main-is:                ArithmeticCounterExamples.hs
     hs-source-dirs:         examples/what4
-    build-depends:          base
-                          , containers
+    build-depends:          base            >= 4.9  && < 5
+                          , containers      >= 0.4 && < 0.9
                           , copilot
                           , copilot-theorem
     default-language:       Haskell2010
@@ -102,7 +102,7 @@ executable what4-arithmetic-counterexamples
 executable what4-structs
     main-is:                Structs.hs
     hs-source-dirs:         examples/what4
-    build-depends:          base
+    build-depends:          base            >= 4.9  && < 5
                           , copilot
                           , copilot-theorem
     default-language:       Haskell2010


### PR DESCRIPTION
Adds missing dependency bounds to executable stanzas in `copilot.cabal`, as proposed in #735.

The bounds follow existing package conventions:
- `base >= 4.9 && < 5`
- `containers >= 0.4 && < 0.9`

Validated with:
```sh
cabal test all
cd copilot && cabal check
cabal v2-sdist copilot
```